### PR TITLE
Fixing CMakeLists.txt to point to the new location of Doxyfile.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ ENDIF()
 # Doxygen
 find_package(Doxygen)
 if (DOXYGEN_FOUND)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc/Doxyfile.in
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen/Doxyfile.in
     ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
   add_custom_target(doc
     ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile


### PR DESCRIPTION
The Doxyfile.in was moved with the update to have the plaintext documentation in doc/  The CMakeLists.txt needed to be updated so that it will configure properly.
