### PR TITLE
Updating documentation on stinger_name_create_type to reflect current… 

### DIFF
--- a/src/lib/stinger_core/src/stinger_names.c
+++ b/src/lib/stinger_core/src/stinger_names.c
@@ -137,7 +137,7 @@ stinger_names_free(stinger_names_t ** sn) {
 *
 * @param sn A pointer to a stinger_names struct
 * @param name The string name of the type you wish to create or lookup.
-* @param out A pointer to hold the return value of the mapping (The type on success of -1 on failure)
+* @param out A pointer to hold the return value of the mapping (The type on creation success or -1 on failure)
 *
 * @return 1 if the creation was successful, 0 if a mapping already exists, -1 if the mapping fails
 */


### PR DESCRIPTION
…behavior.

The doxygen for stinger_names_type_create is out of date.  Fixing to reflect current behavior.
