### PR TITLE
At high levels of contention, there could be a measurable performance penalty...

### DIFF
--- a/src/bin/clients/tools/json_rpc_server/src/get_graph_stats.cpp
+++ b/src/bin/clients/tools/json_rpc_server/src/get_graph_stats.cpp
@@ -59,7 +59,7 @@ JSON_RPC_get_graph_stats::operator()(rapidjson::Value * params, rapidjson::Value
 
   int64_t num_vertices = stinger_mapping_nv(S);
   nv.SetInt64(num_vertices);
-  int64_t num_edges = S->cur_ne; //stinger_edges_up_to(S, num_vertices);
+  int64_t num_edges = stinger_total_edges(S);
   ne.SetInt64(num_edges);
   
   max_time_seen.SetInt64(server_state->get_max_time());

--- a/src/lib/stinger_core/inc/stinger_internal.h
+++ b/src/lib/stinger_core/inc/stinger_internal.h
@@ -121,9 +121,6 @@ struct stinger
   uint64_t max_netypes;
   uint64_t max_nvtypes;
 
-  /* uint64_t cur_max_nv; Someday... */
-  uint64_t cur_ne;
-
   uint64_t vertices_start;
   uint64_t physmap_start;
   uint64_t etype_names_start;

--- a/src/lib/stinger_core/src/stinger.c
+++ b/src/lib/stinger_core/src/stinger.c
@@ -969,7 +969,6 @@ update_edge_data (struct stinger * S, struct stinger_eb *eb,
       /* register new edge */
       stinger_outdegree_increment_atomic(S, eb->vertexID, 1);
       stinger_indegree_increment_atomic(S, neighbor, 1);
-      stinger_int64_fetch_add (&S->cur_ne, 1);
 
       if (index >= eb->high)
 	eb->high = index + 1;
@@ -994,7 +993,6 @@ update_edge_data (struct stinger * S, struct stinger_eb *eb,
     stinger_outdegree_increment_atomic(S, eb->vertexID, -1);
     stinger_indegree_increment_atomic(S, e->neighbor, -1);
     stinger_int64_fetch_add (&(eb->numEdges), -1);
-    stinger_int64_fetch_add (&S->cur_ne, -1);
     e->neighbor = neighbor;
   } 
 
@@ -1422,8 +1420,6 @@ stinger_set_initial_edges (struct stinger *G,
 
   assert (G);
   MAP_STING(G);
-
-  G->cur_ne = off[nv];
 
   blkoff = xcalloc (nv + 1, sizeof (*blkoff));
   OMP ("omp parallel for")
@@ -2049,7 +2045,6 @@ stinger_remove_all_edges_of_type (struct stinger *G, int64_t type)
     current_eb->smallStamp = INT64_MAX;
     current_eb->largeStamp = INT64_MIN;
   }
-  stinger_int64_fetch_add (&G->cur_ne, -ne_removed);
 }
 
 const int64_t endian_check = 0x1234ABCD;

--- a/src/lib/stinger_utils/src/stinger_extract.c
+++ b/src/lib/stinger_utils/src/stinger_extract.c
@@ -96,7 +96,7 @@ stinger_extract_mod (/*const*/ struct stinger *S,
   int64_t * restrict mark = mark_out;
 
   const int64_t label_to_match = (label && nsrc? label[srclist[0]] : -1);
-  const int64_t totvol = S->cur_ne / 2; /* assuming undirected */
+  const int64_t totvol = stinger_total_edges(S) / 2; /* assuming undirected */
 
   int64_t nset, frontier_end;
   double setvol = 0.0;


### PR DESCRIPTION
...to global counters like these that require synchronization.

On a single Haswell Intel Xeon E3-1275 v3, the performance difference is small 10-25%.
On a dual Intel Xeon E5-2650 v2, it is close to 3x.
I haven't yet measured the difference on our 4/8 socket systems.
