### PR TITLE
Bug fixes to breadth first search and pagerank

### DIFF
--- a/src/bin/clients/algorithms/pagerank/src/pagerank.c
+++ b/src/bin/clients/algorithms/pagerank/src/pagerank.c
@@ -24,8 +24,9 @@ page_rank(stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double eps
       tmp_pr[v] = 0;
 
       STINGER_FORALL_EDGES_OF_VTX_BEGIN(S, v) {
-	tmp_pr[v] += (((double)pr[STINGER_EDGE_DEST]) / 
-	  ((double) stinger_outdegree(S, STINGER_EDGE_DEST)));
+        int64_t outdegree = stinger_outdegree(S, STINGER_EDGE_DEST);
+        tmp_pr[v] += (((double)pr[STINGER_EDGE_DEST]) / 
+          (double)((outdegree)?outdegree:NV-1));
       } STINGER_FORALL_EDGES_OF_VTX_END();
     }
 

--- a/src/bin/clients/tools/json_rpc_server/src/breadth_first_search.cpp
+++ b/src/bin/clients/tools/json_rpc_server/src/breadth_first_search.cpp
@@ -56,7 +56,7 @@ JSON_RPC_breadth_first_search::operator()(rapidjson::Value * params, rapidjson::
   rapidjson::Value src_str, dst_str, etype, vtype, vtx_name;
 
   /* vertex has no edges -- this is easy */
-  if (stinger_outdegree (S, source) == 0 || stinger_outdegree (S, target) == 0) {
+  if (stinger_outdegree (S, source) == 0 || stinger_indegree (S, target) == 0) {
     result.AddMember("subgraph", a, allocator);
     return 0;
   }


### PR DESCRIPTION
We haven't done much with directed graphs.  The formula for pagerank would result in infinite values and bfs should check the indegree of the target.
