### PR TITLE
Fixed broken SOURCEME script

### DIFF
--- a/SOURCEME.sh
+++ b/SOURCEME.sh
@@ -2,7 +2,7 @@
 
 echo Run this from your build directory ONLY!
 if [ ! -e data ]; then
-  ln -s ../html data
+  ln -s ../util/graph_explorer/ data
 fi
 export PATH=`pwd`/bin:$PATH
 export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
SOURCEME script now correctly links to the proper web status pages instead of the now defuct /html directory.