### PR TITLE
Keep headers in sync between the source and build directories.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,25 @@ set(STINGER_NAME_STR_MAX "255" CACHE STRING "Max string length in physmap")
 
 configure_file(${CMAKE_SOURCE_DIR}/lib/stinger_core/inc/stinger_defs.h.in ${CMAKE_BINARY_DIR}/include/stinger_core/stinger_defs.h @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/lib/stinger_core/inc/stinger_names.h.in ${CMAKE_BINARY_DIR}/include/stinger_core/stinger_names.h @ONLY)
-#file(COPY ${CMAKE_SOURCE_DIR}/lib/stinger_core/inc/stinger_defs.h DESTINATION ${CMAKE_BINARY_DIR}/include/stinger_core/)
-#file(COPY ${CMAKE_SOURCE_DIR}/lib/stinger_core/inc/stinger_names.h DESTINATION ${CMAKE_BINARY_DIR}/include/stinger_core/)
+
+# Define a custom function for copying headers to the build directory
+function(publish_headers header_list destination)
+  set(published_headers "")
+  foreach(header ${${header_list}})
+    get_filename_component(name ${header} NAME)
+    set(output "${destination}/${name}")
+    list(APPEND published_headers ${output})
+    add_custom_command(
+      OUTPUT ${output}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${destination}
+      COMMAND ${CMAKE_COMMAND} -E copy ${header} ${destination}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      DEPENDS ${header}
+    )
+  endforeach()
+  # Overwrite the list of headers in the caller, so targets depend on the published version
+  set(${header_list} ${published_headers} PARENT_SCOPE)
+endfunction()
 
 include_directories("${CMAKE_BINARY_DIR}/include")
 include_directories("${CMAKE_SOURCE_DIR}/external/googletest/include/")

--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -7,7 +7,7 @@ set(headers
 	inc/luc.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/compat")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/compat")
 
 include_directories("${CMAKE_BINARY_DIR}/include/compat")
 

--- a/lib/fmemopen/CMakeLists.txt
+++ b/lib/fmemopen/CMakeLists.txt
@@ -5,7 +5,7 @@ set(headers
 	inc/fmemopen.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/fmemopen")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/fmemopen")
 
 include_directories("${CMAKE_BINARY_DIR}/include/fmemopen")
 

--- a/lib/int_hm_seq/CMakeLists.txt
+++ b/lib/int_hm_seq/CMakeLists.txt
@@ -5,7 +5,7 @@ set(headers
 	inc/int_hm_seq.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/int_hm_seq")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/int_hm_seq")
 
 include_directories("${CMAKE_BINARY_DIR}/include/int_hm_seq")
 include_directories("${CMAKE_BINARY_DIR}/include/stinger_utils")

--- a/lib/int_hm_seq/src/int-hm-seq.c
+++ b/lib/int_hm_seq/src/int-hm-seq.c
@@ -1,5 +1,4 @@
 #include "int_hm_seq.h"
-#include "timer.h"
 
 #include <stdlib.h>
 

--- a/lib/int_ht_seq/CMakeLists.txt
+++ b/lib/int_ht_seq/CMakeLists.txt
@@ -5,7 +5,7 @@ set(headers
 	inc/int_ht_seq.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/int_ht_seq")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/int_ht_seq")
 
 include_directories("${CMAKE_BINARY_DIR}/include/int_ht_seq")
 include_directories("${CMAKE_BINARY_DIR}/include/stinger_utils")

--- a/lib/int_ht_seq/src/int-ht-seq.c
+++ b/lib/int_ht_seq/src/int-ht-seq.c
@@ -1,5 +1,4 @@
 #include "int_ht_seq.h"
-#include "timer.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/lib/intvec/CMakeLists.txt
+++ b/lib/intvec/CMakeLists.txt
@@ -5,7 +5,7 @@ set(headers
 	inc/int64vector.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/int64vector")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/int64vector")
 
 include_directories("${CMAKE_BINARY_DIR}/include/int64vector")
 

--- a/lib/kv_store/CMakeLists.txt
+++ b/lib/kv_store/CMakeLists.txt
@@ -5,7 +5,7 @@ set(headers
 	inc/kv_store.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/kv_store")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/kv_store")
 
 include_directories("${CMAKE_BINARY_DIR}/include/kv_store")
 

--- a/lib/mongo_c_driver/CMakeLists.txt
+++ b/lib/mongo_c_driver/CMakeLists.txt
@@ -18,7 +18,7 @@ set(headers
 	inc/mongo.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/mongo_c_driver")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/mongo_c_driver")
 
 include_directories("${CMAKE_BINARY_DIR}/include/mongo_c_driver")
 

--- a/lib/mongoose/CMakeLists.txt
+++ b/lib/mongoose/CMakeLists.txt
@@ -7,7 +7,7 @@ set(headers
 	inc/mongoose.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/mongoose")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/mongoose")
 
 include_directories("${CMAKE_BINARY_DIR}/include/mongoose")
 

--- a/lib/pugixml/CMakeLists.txt
+++ b/lib/pugixml/CMakeLists.txt
@@ -7,7 +7,7 @@ set(headers
 	inc/pugixml.hpp
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/pugixml")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/pugixml")
 
 include_directories("${CMAKE_BINARY_DIR}/include/pugixml")
 

--- a/lib/rapidjson/CMakeLists.txt
+++ b/lib/rapidjson/CMakeLists.txt
@@ -15,7 +15,7 @@ set(headers
 	include/writer.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/rapidjson")
-file(COPY ${headersInternal} DESTINATION "${CMAKE_BINARY_DIR}/include/rapidjson/internal")
-
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/rapidjson")
+publish_headers(headersInternal "${CMAKE_BINARY_DIR}/include/rapidjson/internal")
+add_custom_target("rapidjson" DEPENDS ${headers} ${headersInternal})
 include_directories("${CMAKE_BINARY_DIR}/include/rapidjson")

--- a/lib/sqlite/CMakeLists.txt
+++ b/lib/sqlite/CMakeLists.txt
@@ -5,7 +5,7 @@ set(headers
 	inc/sqlite3.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/sqlite")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/sqlite")
 
 include_directories("${CMAKE_BINARY_DIR}/include/sqlite")
 

--- a/lib/stinger_alg/CMakeLists.txt
+++ b/lib/stinger_alg/CMakeLists.txt
@@ -23,7 +23,7 @@ set(headers
   inc/streaming_connected_components.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/stinger_alg")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/stinger_alg")
 
 include_directories("${CMAKE_BINARY_DIR}/include/stinger_alg")
 include_directories("${CMAKE_BINARY_DIR}/include/stinger_core")

--- a/lib/stinger_core/CMakeLists.txt
+++ b/lib/stinger_core/CMakeLists.txt
@@ -33,7 +33,7 @@ set(config
 	stinger_defs.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/stinger_core")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/stinger_core")
 
 include_directories("${CMAKE_BINARY_DIR}/include/stinger_core")
 include_directories("${CMAKE_BINARY_DIR}/include/stinger_utils")

--- a/lib/stinger_core/src/stinger_vertex.c
+++ b/lib/stinger_core/src/stinger_vertex.c
@@ -1,6 +1,5 @@
 #include "stinger_vertex.h"
 #include "stinger_atomics.h"
-#include "xml_support.h"
 #include "x86_full_empty.h"
 
 #include <stdlib.h>

--- a/lib/stinger_net/CMakeLists.txt
+++ b/lib/stinger_net/CMakeLists.txt
@@ -56,7 +56,7 @@ foreach(file ${proto})
 	set(_generated_files ${_generated_files} "${CMAKE_BINARY_DIR}/stinger_net/proto/${_file_name}.pb.cc" "${CMAKE_BINARY_DIR}/stinger_net/proto/${_file_name}.pb.h")
 endforeach()
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/stinger_net")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/stinger_net")
 
 include_directories("${CMAKE_BINARY_DIR}/")
 include_directories("${CMAKE_BINARY_DIR}/stinger_net")

--- a/lib/stinger_utils/CMakeLists.txt
+++ b/lib/stinger_utils/CMakeLists.txt
@@ -27,11 +27,13 @@ set(headers
 	inc/xml_support.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/stinger_utils")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/stinger_utils")
 
 include_directories("${CMAKE_BINARY_DIR}/include/stinger_utils")
 include_directories("${CMAKE_BINARY_DIR}/include/stinger_core")
 
-add_library(stinger_utils SHARED ${sources} ${headers})
-
+# Need to declare an explicit dependency on rapidjson headers, since there's no associated target
+set_source_files_properties("${CMAKE_BINARY_DIR}/include/rapidjson/document.h" GENERATED)
+add_library(stinger_utils SHARED ${sources} ${headers} "${CMAKE_BINARY_DIR}/include/rapidjson/document.h")
+add_dependencies(stinger_utils rapidjson)
 target_link_libraries(stinger_utils stinger_core fmemopen int_hm_seq string compat)

--- a/lib/string/CMakeLists.txt
+++ b/lib/string/CMakeLists.txt
@@ -4,7 +4,7 @@ set(sources
 set(headers
 	inc/astring.h)
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/string")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/string")
 
 include_directories("${CMAKE_BINARY_DIR}/include/string")
 

--- a/lib/vtx_set/CMakeLists.txt
+++ b/lib/vtx_set/CMakeLists.txt
@@ -5,7 +5,7 @@ set(headers
 	inc/vtx_set.h
 )
 
-file(COPY ${headers} DESTINATION "${CMAKE_BINARY_DIR}/include/vtx_set")
+publish_headers(headers "${CMAKE_BINARY_DIR}/include/vtx_set")
 
 include_directories("${CMAKE_BINARY_DIR}/include/vtx_set")
 


### PR DESCRIPTION
Use a custom command to keep headers in sync between the source and build directories. Fixes #172.

This patch adds a custom build step to copy each header into the build directory. This was previously implemented as a file copy that happened only during project configuration. Now, when a header is edited in the source directory, the new build step will trigger a copy to the build directory, and all dependent targets will get rebuilt. 

Also deleted a few broken header includes that ended up being unused.
