### PR TITLE
Servers should sleep instead of waiting for input.

### DIFF
--- a/src/clients/tools/json_rpc_server/src/json_rpc_server.cpp
+++ b/src/clients/tools/json_rpc_server/src/json_rpc_server.cpp
@@ -195,8 +195,8 @@ main (int argc, char ** argv)
   if(unleash_daemon) {
     while(1) { sleep(10); }
   } else {
-    printf("Press <q> to shut down the server...\n");
-    while (getchar() != 'q');
+    printf("Press Ctrl-C to shut down the server...\n");
+    while(1) { sleep(10); }
   }
 
   return 0;

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -397,11 +397,9 @@ int main(int argc, char *argv[])
     close (start_pipe[1]);
     while(1) { sleep(10); }
   } else {
-    LOG_I("Press <q> to shut down the server...");
-    while (getchar() != 'q');
+    LOG_I("Press Ctrl-C to shut down the server...");
+    while(1) { sleep(10); }
   }
-
-  cleanup ();
 
   return 0;
 }


### PR DESCRIPTION
stinger_server and stinger_json_rpc_server used to wait for the user to enter `q` before exiting. Two problems with this:

1. If the server was run in the background, `getchar` would return immediately, using 100% CPU.
2. Pressing `q` didn't actually exit.

Now we just sleep in a loop and wait for a signal.