### PR TITLE
Fix two instances of 'control reaches end of non-void function'.

### DIFF
--- a/src/server/src/alg_handling.cpp
+++ b/src/server/src/alg_handling.cpp
@@ -282,6 +282,7 @@ new_connection_handler(void * data)
   }
 
   free(accepted_sock);
+  return NULL;
 }
 
 void *

--- a/src/server/src/batch_server.cpp
+++ b/src/server/src/batch_server.cpp
@@ -77,6 +77,7 @@ handle_stream(void * args)
       }
     }
   }
+  return NULL;
 }
 
 void *


### PR DESCRIPTION
This was causing clang to detect UB and generate illegal instructions.