### PR TITLE
Allow `stinger_outdegree_get` to be used from built library.

### DIFF
--- a/lib/stinger_core/inc/stinger.h
+++ b/lib/stinger_core/inc/stinger.h
@@ -183,10 +183,8 @@ stinger_indegree_increment_atomic(const stinger_t * S, vindex_t v, vdegree_t d);
 
 /* OUT DEGREE */
 
-static inline vdegree_t
-stinger_outdegree_get(const stinger_t * S, vindex_t v) {
-     return ((const stinger_vertices_t*)(S->storage))->vertices[v].outDegree;
-}
+vdegree_t
+stinger_outdegree_get(const stinger_t * S, vindex_t v);
 
 vdegree_t
 stinger_outdegree_set(const stinger_t * S, vindex_t v, vdegree_t d);

--- a/lib/stinger_core/src/stinger.c
+++ b/lib/stinger_core/src/stinger.c
@@ -90,8 +90,10 @@ stinger_indegree_increment_atomic(const stinger_t * S, vindex_t v, vdegree_t d) 
 
 /* OUT DEGREE */
 
-extern vdegree_t
-stinger_outdegree_get(const stinger_t * S, vindex_t v);
+inline vdegree_t
+stinger_outdegree_get(const stinger_t * S, vindex_t v) {
+     return ((const stinger_vertices_t*)(S->storage))->vertices[v].outDegree;
+}
 
 inline vdegree_t
 stinger_outdegree_set(const stinger_t * S, vindex_t v, vdegree_t d) {


### PR DESCRIPTION
Fixes #200. 

The fix in #203 doesn't work. Running a `nm -m libstinger_core | grep stinger_outdegree_get` after building the library with that fix shows the symbol as a non-external symbol.

```shell
git:(3df00b1) ✗ nm -m libstinger_core.dylib | grep stinger_outdegree_get
00000000000020a0 (__TEXT,__text) non-external _stinger_outdegree_get
```

I think its because we can't have `static` and `extern` for the same function (Stackoverflow links - [Link 1](https://stackoverflow.com/questions/13788035/why-declaration-by-extern-doesnt-work-with-static-functions-in-c), [Link 2](https://stackoverflow.com/questions/7920516/extern-on-a-static-function-in-c)).

In this PR, I've basically gone back to the state before dcddcdae323dee9ac062363cb8061731e5067d1d for this function.

`nm` shows the `stinger_outdegree_get` symbol to be external now.
```shell
 git:(outdegree-extern) ✗ nm -m libstinger_core.dylib | grep stinger_outdegree_get
00000000000020a0 (__TEXT,__text) external _stinger_outdegree_get
```

I also tested calling it from Julia wrapper I'm working on and it works.