### PR TITLE
Optimize batch insertion of edges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ add_subdirectory(src)
 enable_testing()
 add_test(NamesTest ${CMAKE_BINARY_DIR}/bin/stinger_names_test)
 add_test(StingerCoreTest ${CMAKE_BINARY_DIR}/bin/stinger_core_test)
+add_test(StingerBatchTest ${CMAKE_BINARY_DIR}/bin/stinger_batch_test)
 add_test(StingerPhysmapTest ${CMAKE_BINARY_DIR}/bin/stinger_physmap_test)
 add_test(StingerTraversalTest ${CMAKE_BINARY_DIR}/bin/stinger_traversal_test)
 add_test(StingerPagerankTest ${CMAKE_BINARY_DIR}/bin/stinger_pagerank_test)
@@ -192,6 +193,7 @@ add_custom_target(check
   DEPENDS
     stinger_names_test
     stinger_core_test
+    stinger_batch_test
     stinger_physmap_test
     stinger_traversal_test
     stinger_pagerank_test

--- a/lib/stinger_core/CMakeLists.txt
+++ b/lib/stinger_core/CMakeLists.txt
@@ -24,6 +24,7 @@ set(headers
 	inc/stinger_vertex.h
 	inc/x86_full_empty.h
 	inc/xmalloc.h
+	inc/stinger_batch_insert.h
 )
 
 set(config
@@ -38,4 +39,7 @@ include_directories("${CMAKE_BINARY_DIR}/include/stinger_utils")
 
 set_source_files_properties(${config} PROPERTIES GENERATED TRUE)
 add_library(stinger_core SHARED ${sources} ${headers} ${config})
+if(OPENMP_FOUND)
+  target_compile_definitions(stinger_core PUBLIC _GLIBCXX_PARALLEL)
+endif()
 target_link_libraries(stinger_core compat)

--- a/lib/stinger_core/inc/stinger_batch_insert.h
+++ b/lib/stinger_core/inc/stinger_batch_insert.h
@@ -1,0 +1,590 @@
+/*
+ * stinger_batch_insert.h
+ * Author: Eric Hein <ehein6@gatech.edu>
+ * Date: 10/24/2016
+ * Purpose:
+ *   Provides optimized edge insert/update routines for stinger.
+ *   Multiple updates for the same source vertex are dispatched to each thread,
+ *   reducing the number of edge-list traversals that need to be done.
+ *
+ * Accepts a pair of random-access iterators to the range of edge updates to perform.
+ * Caller must also provide an adapter template argument: a struct of static functions
+ * to access the source, destination, weight, time, and result code of the update.
+ * This implementation handles duplicates and sets the return code correctly.
+ */
+
+#ifndef STINGER_BATCH_INSERT_H_
+#define STINGER_BATCH_INSERT_H_
+
+#include "stinger.h"
+#include "stinger_internal.h"
+#include "stinger_atomics.h"
+#include "x86_full_empty.h"
+#define LOG_AT_I
+#include "stinger_error.h"
+#undef LOG_AT_I
+
+#include <vector>
+#include <algorithm>
+#include <utility>
+#include <cmath>
+
+// *** Public interface (definitions at end of file) ***
+template<typename adapter, typename iterator>
+void stinger_batch_incr_edges(stinger_t *G, iterator begin, iterator end);
+template<typename adapter, typename iterator>
+void stinger_batch_insert_edges(stinger_t * G, iterator begin, iterator end);
+template<typename adapter, typename iterator>
+void stinger_batch_incr_edge_pairs(stinger_t * G, iterator begin, iterator end);
+template<typename adapter, typename iterator>
+void stinger_batch_insert_edge_pairs(stinger_t * G, iterator begin, iterator end);
+
+// *** Implementation ***
+namespace gt { namespace stinger {
+
+/*
+ * Rather than add these template arguments to every function in the file, just wrap everything in a template class
+ *
+ * adapter - provides static methods for accessing fields of an update
+ * iterator - iterator for a collection of updates
+ */
+template<typename adapter, typename iterator>
+class BatchInserter
+{
+protected:
+    // Everything in this class is protected and static, these friend functions are the only public interface
+    BatchInserter() {}
+    friend void stinger_batch_incr_edges<adapter, iterator>(stinger_t *G, iterator begin, iterator end);
+    friend void stinger_batch_insert_edges<adapter, iterator>(stinger_t * G, iterator begin, iterator end);
+    friend void stinger_batch_incr_edge_pairs<adapter, iterator>(stinger_t * G, iterator begin, iterator end);
+    friend void stinger_batch_insert_edge_pairs<adapter, iterator>(stinger_t * G, iterator begin, iterator end);
+
+    // what 'iterator' points to
+    typedef typename std::iterator_traits<iterator>::value_type update;
+
+    // Result codes
+    // Caller initializes result code to 0, and expects 0 if edge is already present.
+    // But we need to use this field to track if the update has been processed yet.
+    // We use a fixed offset, then subtract it before returning to match behavior of functions like stinger_incr_edge.
+    static const int64_t result_code_offset = 10;
+    enum result_codes {
+        PENDING =           0,
+        EDGE_ADDED =        1 + result_code_offset,
+        EDGE_UPDATED =      0 + result_code_offset,
+        EDGE_NOT_ADDED =   -1 + result_code_offset
+    };
+
+    // Set of functions to sort/filter a collection of updates by source vertex
+    struct source_funcs
+    {
+        static int64_t
+        get(const update &x){
+            return adapter::get_source(x);
+        }
+        static void
+        set(update &x, int64_t neighbor){
+            adapter::set_source(x, neighbor);
+        }
+        static bool
+        equals(const update &a, const update &b){
+            return adapter::get_source(a) == adapter::get_source(b);
+        }
+        static bool
+        compare(const update &a, const update &b){
+            return adapter::get_source(a) < adapter::get_source(b);
+        }
+        static bool
+        sort(const update &a, const update &b){
+            if (adapter::get_type(a) != adapter::get_type(b))
+                return adapter::get_type(a) < adapter::get_type(b);
+            if (adapter::get_source(a) != adapter::get_source(b))
+                return adapter::get_source(a) < adapter::get_source(b);
+            if (adapter::get_dest(a) != adapter::get_dest(b))
+                return adapter::get_dest(a) < adapter::get_dest(b);
+            if (adapter::get_time(a) != adapter::get_time(b))
+                return adapter::get_time(a) < adapter::get_time(b);
+            return false;
+        }
+    };
+
+    // Set of functions to sort/filter a collection of updates by destination vertex
+    struct dest_funcs
+    {
+        static int64_t
+        get(const update &x){
+            return adapter::get_dest(x);
+        }
+        static void
+        set(update &x, int64_t neighbor){
+            adapter::set_dest(x, neighbor);
+        }
+        static bool
+        equals(const update &a, const update &b){
+            return adapter::get_dest(a) == adapter::get_dest(b);
+        }
+        static bool
+        compare(const update &a, const update &b){
+            return adapter::get_dest(a) < adapter::get_dest(b);
+        }
+        static bool
+        sort(const update &a, const update &b){
+            if (adapter::get_type(a) != adapter::get_type(b))
+                return adapter::get_type(a) < adapter::get_type(b);
+            if (adapter::get_dest(a) != adapter::get_dest(b))
+                return adapter::get_dest(a) < adapter::get_dest(b);
+            if (adapter::get_source(a) != adapter::get_source(b))
+                return adapter::get_source(a) < adapter::get_source(b);
+            if (adapter::get_time(a) != adapter::get_time(b))
+                return adapter::get_time(a) < adapter::get_time(b);
+            return false;
+        }
+    };
+
+    // Finds an element in a sorted range using binary search
+    // http://stackoverflow.com/a/446327/1877086
+    template<class Iter, class T, class Compare>
+    static Iter
+    binary_find(Iter begin, Iter end, T val, Compare comp)
+    {
+        // Finds the lower bound in at most log(last - first) + 1 comparisons
+        Iter i = std::lower_bound(begin, end, val, comp);
+
+        if (i != end && !(comp(val, *i)))
+            return i; // found
+        else
+            return end; // not found
+    }
+
+    // Find the first pending update with destination 'dest'
+    template<class use_dest>
+    static iterator
+    find_updates(iterator begin, iterator end, int64_t neighbor)
+    {
+        // Create a dummy update object with the neighbor we are looking for
+        update key;
+        use_dest::set(key, neighbor);
+        // Find the updates for this neighbor
+        iterator pos = binary_find(begin, end, key, use_dest::compare);
+        // If the first update is not pending, we have already done all the updates for this neighbor
+        if (pos != end && adapter::get_result(*pos) == PENDING) return pos;
+        else return end;
+    }
+
+    // Keeps track of the next pending update to insert into the graph
+    class next_update_tracker
+    {
+    protected:
+        iterator pos;
+        iterator end;
+    public:
+        next_update_tracker(iterator begin, iterator end)
+        : pos(begin), end(end) {}
+
+        iterator
+        operator () ()
+        {
+            while (pos != end && adapter::get_result(*pos) != PENDING) { ++pos; }
+            return pos;
+        }
+    };
+
+    /*
+     * Arguments:
+     * result - Result code to set on first update for a neighbor. Result of duplicate updates will always be EDGE_UPDATED.
+     * create - Are we inserting into an empty slot, or just updating an existing slot?
+     * pos - pointer to first update
+     * updates_end - pointer to end of update list
+     * G - pointer to STINGER
+     * eb - pointer to edge block
+     * e - edge index within block
+     * operation - EDGE_WEIGHT_SET or EDGE_WEIGHT_INCR
+     */
+    template<int64_t direction, class use_dest>
+    static void
+    do_edge_updates(
+        int64_t result, bool create, iterator pos, iterator updates_end,
+        stinger_t * G, stinger_eb *eb, size_t e, int64_t operation)
+    {
+        // 'pos' points to the first update for this edge slot; there may be more than one, or none if it equals 'updates_end'
+        // Keep incrementing the iterator until we reach an update with a different neighbor
+        for (iterator u = pos; u != updates_end && use_dest::get(*u) == use_dest::get(*pos); ++u) {
+            int64_t neighbor = use_dest::get(*pos);
+            int64_t weight = adapter::get_weight(*u);
+            int64_t time = adapter::get_time(*u);
+            if (u == pos) {
+                adapter::set_result(*u, result);
+                update_edge_data_and_direction (G, eb, e, neighbor, weight, time, direction, create ? EDGE_WEIGHT_SET : operation);
+            } else {
+                adapter::set_result(*u, EDGE_UPDATED);
+                update_edge_data_and_direction (G, eb, e, neighbor, weight, time, direction, operation);
+            }
+        }
+    }
+
+    /*
+     * The core algorithm for updating edges in one direction.
+     * Similar to stinger_update_directed_edge(), but optimized to perform several updates for the same vertex.
+     * direction - are we updating out-edges or in-edges?
+     * use_dest - Either source_funcs or dest_funcs (allows us to swap source/destination easily)
+     */
+    template<int64_t direction, class use_dest>
+    static void
+    update_directed_edges_for_vertex(
+            stinger_t *G, int64_t src, int64_t type,
+            iterator updates_begin,
+            iterator updates_end,
+            int64_t operation)
+    {
+
+        MAP_STING(G);
+        stinger_eb *ebpool_priv = ebpool->ebpool;
+        curs curs = etype_begin (G, src, type);
+
+        assert(direction == STINGER_EDGE_DIRECTION_OUT || direction == STINGER_EDGE_DIRECTION_IN);
+
+        /*
+    Possibilities:
+    1: Edge already exists and only needs updated.
+    2: Edge does not exist, fits in an existing block.
+    3: Edge does not exist, needs a new block.
+    */
+
+        // Track the next edge that should be inserted
+        next_update_tracker next_update(updates_begin, updates_end);
+
+        /* 1: Check if the edge already exists. */
+        for (stinger_eb *tmp = ebpool_priv + curs.eb; tmp != ebpool_priv; tmp = ebpool_priv + readff(&tmp->next)) {
+            if(type == tmp->etype) {
+                size_t k, endk;
+                endk = tmp->high;
+                // For each edge in the block
+                for (k = 0; k < endk; ++k) {
+                    // Mask off direction bits to get the raw neighbor of this edge
+                    int64_t dest = (tmp->edges[k].neighbor & (~STINGER_EDGE_DIRECTION_MASK));
+                    // Find updates for this destination
+                    iterator u = find_updates<use_dest>(next_update(), updates_end, dest);
+                    // If we already have an in-edge for this destination, we will reuse the edge slot
+                    // But the return code should reflect that we added an edge
+                    int64_t result = (direction & tmp->edges[k].neighbor) ? EDGE_UPDATED : EDGE_ADDED;
+                    do_edge_updates<direction, use_dest>(result, false, u, updates_end,
+                        G, tmp, k, operation);
+                }
+            }
+        }
+
+        while (next_update() != updates_end) {
+            eb_index_t * block_ptr = curs.loc;
+            curs.eb = readff(curs.loc);
+            /* 2: The edge isn't already there.  Check for an empty slot. */
+            for (stinger_eb *tmp = ebpool_priv + curs.eb; tmp != ebpool_priv; tmp = ebpool_priv + readff(&tmp->next)) {
+                if(type == tmp->etype) {
+                    size_t k, endk;
+                    endk = tmp->high;
+                    // This time we go past the high water mark to look at the empty edge slots
+                    for (k = 0; k < STINGER_EDGEBLOCKSIZE; ++k) {
+                        int64_t myNeighbor = (tmp->edges[k].neighbor & (~STINGER_EDGE_DIRECTION_MASK));
+
+                        // Check for edges that were added by another thread since we last checked
+                        if (k < endk) {
+                            // Find updates for this destination
+                            iterator u = find_updates<use_dest>(next_update(), updates_end, myNeighbor);
+                            // If we already have an in-edge for this destination, we will reuse the edge slot
+                            // But the return code should reflect that we added an edge
+                            int64_t result = (direction & tmp->edges[k].neighbor) ? EDGE_UPDATED : EDGE_ADDED;
+                            do_edge_updates<direction, use_dest>(result, false, u, updates_end,
+                                G, tmp, k, operation);
+                        }
+
+                        if (myNeighbor < 0 || k >= endk) {
+                            // Found an empty slot for the edge, lock it and check again to make sure
+                            int64_t timefirst = readfe ((uint64_t *)&(tmp->edges[k].timeFirst) );
+                            int64_t thisEdge = (tmp->edges[k].neighbor & (~STINGER_EDGE_DIRECTION_MASK));
+                            endk = tmp->high;
+
+                            iterator u = find_updates<use_dest>(next_update(), updates_end, thisEdge);
+                            if (thisEdge < 0 || k >= endk) {
+                                // Slot is empty, add the edge
+                                do_edge_updates<direction, use_dest>(EDGE_ADDED, true, next_update(), updates_end,
+                                    G, tmp, k, operation);
+                            } else if (u != updates_end) {
+                                // Another thread just added the edge. Do a normal update
+                                int64_t result = (direction & tmp->edges[k].neighbor) ? EDGE_UPDATED : EDGE_ADDED;
+                                do_edge_updates<direction, use_dest>(result, false, u, updates_end,
+                                    G, tmp, k, operation);
+                                writexf ( (uint64_t *)&(tmp->edges[k].timeFirst), timefirst);
+                            } else {
+                                // Another thread claimed the slot for a different edge, unlock and keep looking
+                                writexf ( (uint64_t *)&(tmp->edges[k].timeFirst), timefirst);
+                            }
+                        }
+                        if (next_update() == updates_end) { return; }
+                    }
+                }
+
+                block_ptr = &(tmp->next);
+            }
+
+            /* 3: Needs a new block to be inserted at end of list. */
+            // Try to lock the tail pointer of the last block
+            eb_index_t old_eb = readfe (block_ptr);
+            if (!old_eb) {
+                // Create a new edge block
+                eb_index_t newBlock = new_eb (G, type, src);
+                if (newBlock == 0) {
+                    // Ran out of edge blocks!
+                    writeef (block_ptr, (uint64_t)old_eb);
+                    while(next_update() != updates_end)
+                    {
+                        adapter::set_result(*next_update(), EDGE_NOT_ADDED);
+                    }
+                    return;
+                } else {
+                    // Add our edge to the first slot in the new edge block
+                    do_edge_updates<direction, use_dest>(EDGE_ADDED, true, next_update(), updates_end,
+                        G, ebpool_priv + newBlock, 0, operation);
+                    // Add the block to the list
+                    ebpool_priv[newBlock].next = 0;
+                    push_ebs (G, 1, &newBlock);
+                    // Unlock the tail pointer
+                    writeef (block_ptr, (uint64_t)newBlock);
+                }
+            } else {
+                // Another thread already added a block, unlock and try again
+                writeef (block_ptr, (uint64_t)old_eb);
+            }
+        }
+    }
+
+    template <class use_source>
+    static bool same_source_and_type(const iterator &a, const iterator &b)
+    {
+        return adapter::get_type(*a) == adapter::get_type(*b)
+            && use_source::equals(*a, *b);
+    }
+
+    /*
+     * Splits a range of updates into chunks that all update the same source,
+     * then calls update_directed_edges_for_vertex() in parallel on each range
+     *
+     * Template arguments:
+     * direction - are we updating out-edges or in-edges?
+     * use_source - set of functions to use for working with the source vertex (source_funcs or dest_funcs)
+     * use_dest - set of functions to use for working with the destination vertex (source_funcs or dest_funcs)
+     */
+    template<int64_t direction, class use_source, class use_dest>
+    static void
+    do_batch_update(stinger_t * G, iterator updates_begin, iterator updates_end, int64_t operation)
+    {
+        typedef typename std::vector<iterator>::iterator iterator_ptr;
+        typedef typename std::pair<iterator, iterator> range;
+        typedef typename std::vector<range>::iterator range_iterator;
+
+        // Sort by type, src, dst, time ascending
+        LOG_V("Sorting...");
+        std::sort(updates_begin, updates_end, use_source::sort);
+
+        // Get a list of pointers to each element
+        LOG_V("Finding unique sources...");
+        int64_t num_updates = std::distance(updates_begin, updates_end);
+        std::vector<iterator> pointers(num_updates);
+        OMP("omp parallel for")
+        for (int64_t i = 0; i < num_updates; ++i) { pointers[i] = updates_begin + i; }
+
+        // Reduce down to a list of pointers to the beginning of each range of unique source ID's
+        // NOTE: using std::back_inserter here would prevent std::unique_copy from running in parallel
+        //       So instead, allocate room for all the updates and shrink the vector afterwards
+        std::vector<iterator> unique_sources(num_updates);
+        iterator_ptr last_unique_source = std::unique_copy(
+            pointers.begin(), pointers.end(), unique_sources.begin(), same_source_and_type<use_source>);
+        unique_sources.erase(last_unique_source, unique_sources.end());
+        // Now each consecutive pair of elements represents a range of updates for the same type and source ID
+        unique_sources.push_back(updates_end);
+
+        // Split up long ranges of updates for the same source vertex
+        LOG_V("Splitting ranges...");
+        std::vector<range> update_ranges;
+        OMP("omp parallel for")
+        for (iterator_ptr ptr = unique_sources.begin(); ptr < unique_sources.end()-1; ++ptr)
+        {
+            iterator begin = *ptr;
+            iterator end = *(ptr + 1);
+
+            // Calculate number of updates for each range
+            size_t num_updates = std::distance(begin, end);
+            size_t num_ranges = omp_get_num_threads();
+            size_t updates_per_range = std::floor((double)num_updates / num_ranges);
+
+            std::vector<range> local_ranges; local_ranges.reserve(num_ranges);
+            if (updates_per_range < omp_get_num_threads())
+            {
+                // If there aren't many updates, just give them all to one thread
+                local_ranges.push_back(make_pair(begin, end));
+            } else {
+                // Split the updates evenly amoung threads
+                for (size_t i = 0; i < num_ranges-1; ++i)
+                {
+                    local_ranges.push_back(make_pair(begin, begin + updates_per_range));
+                    begin += updates_per_range;
+                }
+                // Last range may be a different size if work doesn't divide evenly
+                local_ranges.push_back(make_pair(begin, end));
+            }
+
+            // Combine all ranges into shared list
+            OMP("omp critical")
+            update_ranges.insert(update_ranges.end(), local_ranges.begin(), local_ranges.end());
+        }
+
+
+        LOG_V_A("Entering parallel update loop: %ld updates for %ld vertices.",
+            std::distance(updates_begin, updates_end), unique_sources.size()-1);
+        OMP("omp parallel for schedule(dynamic)")
+        for (range_iterator range = update_ranges.begin(); range < update_ranges.end(); ++range)
+        {
+            // Get this thread's range of updates
+            iterator begin = range->first;
+            iterator end = range->second;
+            // Each range guaranteed to have same edge type and source vertex
+            int64_t type = adapter::get_type(*begin);
+            int64_t source = use_source::get(*begin);
+
+            LOG_D_A("Thread %d processing %ld updates (%ld -> *)", omp_get_thread_num(), std::distance(begin, end), source);
+            update_directed_edges_for_vertex<direction, use_dest>(G, source, type, begin, end, operation);
+        }
+    }
+
+    static bool
+    source_less_than_destination(const update &x){
+        return adapter::get_source(x) < adapter::get_dest(x);
+    }
+
+    // We use the result field to keep track of which updates have been performed
+    // Between IN and OUT iterations, we clear it out to make sure all the updates are performed again
+    static void
+    clear_results(iterator begin, iterator end)
+    {
+        OMP("omp parallel for")
+        for (iterator u = begin; u < end; ++u) {
+            int64_t result = adapter::get_result(*u);
+            switch (result){
+                case EDGE_ADDED:
+                case EDGE_UPDATED:
+                case EDGE_NOT_ADDED:
+                    // Reset return code so we process this update next iteration
+                    adapter::set_result(*u, PENDING);
+                    break;
+                case EDGE_ADDED-result_code_offset:
+                case EDGE_NOT_ADDED-result_code_offset:
+                    // Caller must have set the return code, leave it be
+                    break;
+                case PENDING:
+                default:
+                    // We didn't finish all the updates, or invalid codes were set
+                    assert(0);
+
+            }
+        }
+    }
+
+    static void
+    remap_results(iterator begin, iterator end)
+    {
+        OMP("omp parallel for")
+        for (iterator u = begin; u < end; ++u) {
+            int64_t result = adapter::get_result(*u);
+            switch (result){
+                case EDGE_ADDED:
+                case EDGE_UPDATED:
+                case EDGE_NOT_ADDED:
+                    // Subtract 10 to get back to return code caller expects
+                    adapter::set_result(*u, result - result_code_offset);
+                    break;
+                case EDGE_ADDED-result_code_offset:
+                case EDGE_NOT_ADDED-result_code_offset:
+                    // Caller must have set the return code, leave it be
+                    break;
+                case PENDING:
+                default:
+                    // We didn't finish all the updates, or invalid codes were set
+                    assert(0);
+
+            }
+        }
+    }
+
+    static void
+    batch_update_dispatch(stinger_t * G, iterator updates_begin, iterator updates_end, int64_t operation, bool directed)
+    {
+        // Each edge is stored in two places: the out-edge at the source, and the in-edge at the destination
+        // First iteration: group by source and update out-edges
+        // Second iteration: group by destination and update in-edges
+        // But, in order to avoid deadlock with concurrent deletions, we must always lock edges in the same order
+        LOG_V("Partitioning batch to obey ordering constraints...");
+        const iterator pos = std::partition(updates_begin, updates_end, source_less_than_destination);
+
+        const int64_t OUT = STINGER_EDGE_DIRECTION_OUT;
+        const int64_t IN = STINGER_EDGE_DIRECTION_IN;
+
+        // All elements between begin and pos have src < dest. Update the out-edge slot first
+        LOG_V("Beginning OUT updates for first half of batch...");
+        do_batch_update<OUT, source_funcs, dest_funcs>(G, updates_begin, pos, operation);
+        clear_results(updates_begin, pos);
+        LOG_V("Beginning IN updates for first half of batch...");
+        do_batch_update<IN, dest_funcs, source_funcs>(G, updates_begin, pos, operation);
+
+        // All elements between pos and end have src > dest. Update the in-edge slot first
+        LOG_V("Beginning IN updates for second half of batch...");
+        do_batch_update<IN, dest_funcs, source_funcs>(G, pos, updates_end, operation);
+        clear_results(pos, updates_end);
+        LOG_V("Beginning OUT updates for second half of batch...");
+        do_batch_update<OUT, source_funcs, dest_funcs>(G, pos, updates_end, operation);
+
+        // For undirected, do the same updates again in the opposite direction
+        if (!directed)
+        {
+            // NOTE We are discarding the return code from the first update, assuming that it will be the same in both directions
+            clear_results(updates_begin, updates_end);
+
+            // All elements between begin and pos have dest < src. Update the in-edge slot first
+            do_batch_update<OUT, dest_funcs, source_funcs>(G, updates_begin, pos, operation);
+            clear_results(updates_begin, pos);
+            do_batch_update<IN, source_funcs, dest_funcs>(G, updates_begin, pos, operation);
+
+            // All elements between pos and end have dest > src. Update the out-edge slot first
+            do_batch_update<IN, source_funcs, dest_funcs>(G, pos, updates_end, operation);
+            clear_results(pos, updates_end);
+            do_batch_update<OUT, dest_funcs, source_funcs>(G, pos, updates_end, operation);
+        }
+
+        remap_results(updates_begin, updates_end);
+    }
+}; // end of class batch insert
+
+}} // end namespace gt::stinger
+
+template<typename adapter, typename iterator>
+void
+stinger_batch_incr_edges(stinger_t *G, iterator begin, iterator end)
+{
+    gt::stinger::BatchInserter<adapter, iterator>::batch_update_dispatch(G, begin, end, EDGE_WEIGHT_INCR, true);
+}
+template<typename adapter, typename iterator>
+void
+stinger_batch_insert_edges(stinger_t * G, iterator begin, iterator end)
+{
+    gt::stinger::BatchInserter<adapter, iterator>::batch_update_dispatch(G, begin, end, EDGE_WEIGHT_SET, true);
+}
+template<typename adapter, typename iterator>
+void
+stinger_batch_incr_edge_pairs(stinger_t * G, iterator begin, iterator end)
+{
+    gt::stinger::BatchInserter<adapter, iterator>::batch_update_dispatch(G, begin, end, EDGE_WEIGHT_INCR, false);
+}
+template<typename adapter, typename iterator>
+void
+stinger_batch_insert_edge_pairs(stinger_t * G, iterator begin, iterator end)
+{
+    gt::stinger::BatchInserter<adapter, iterator>::batch_update_dispatch(G, begin, end, EDGE_WEIGHT_SET, false);
+}
+
+#endif //STINGER_BATCH_INSERT_H_

--- a/lib/stinger_core/inc/stinger_internal.h
+++ b/lib/stinger_core/inc/stinger_internal.h
@@ -199,6 +199,7 @@ void update_edge_data_and_direction (struct stinger * S, struct stinger_eb *eb,
 
 void remove_edge (struct stinger * S, struct stinger_eb *eb, uint64_t index);
 
+eb_index_t new_eb (struct stinger * S, int64_t etype, int64_t from);
 void new_ebs (struct stinger * S, eb_index_t *out, size_t neb, int64_t etype, int64_t from);
 
 void push_ebs (struct stinger *G, size_t neb,

--- a/lib/stinger_core/src/stinger.c
+++ b/lib/stinger_core/src/stinger.c
@@ -904,7 +904,7 @@ stinger_free_all (struct stinger *S)
 
 /* TODO inspect possibly move out with other EB POOL stuff */
 
-static eb_index_t new_eb (struct stinger * S, int64_t etype, int64_t from)
+eb_index_t new_eb (struct stinger * S, int64_t etype, int64_t from)
 {
   MAP_STING(S);
   size_t k;

--- a/src/server/src/batch.cpp
+++ b/src/server/src/batch.cpp
@@ -11,6 +11,7 @@ extern "C" {
 #include "stinger_core/stinger_atomics.h"
 #include "stinger_core/xmalloc.h"
 }
+#include "stinger_core/stinger_batch_insert.h"
 
 using namespace gt::stinger;
 
@@ -109,6 +110,202 @@ handle_edge_names_types(EdgeInsertion & in, stinger_t * S, std::string & src, st
   }
 }
 
+// Allows an EdgeInsertion to be passed to stinger_batch functions
+struct EdgeInsertionAdapter
+{
+    typedef EdgeInsertion update;
+
+    static int64_t get_type(const update &u) { return u.type(); }
+    static void set_type(update &u, int64_t v) { u.set_type(v); }
+    static int64_t get_source(const update &u) { return u.source(); }
+    static void set_source(update &u, int64_t v) { u.set_source(v); }
+    static int64_t get_dest(const update &u) { return u.destination(); }
+    static void set_dest(update &u, int64_t v) { u.set_destination(v); }
+    static int64_t get_weight(const update &u) { return u.weight(); }
+    static int64_t get_time(const update &u) { return u.time(); }
+    static int64_t get_result(const update& u) { return u.result(); }
+    static void set_result(update &u, int64_t v) { u.set_result(v); }
+};
+
+template <int64_t type>
+void process_insertions(stinger_t * S, StingerBatch & batch)
+{
+    OMP("omp parallel for")
+    for (size_t i = 0; i < batch.insertions_size(); i++)
+    {
+        EdgeInsertion & in = *batch.mutable_insertions(i);
+        int64_t u = -1, v = -1;
+        std::string src, dest;
+        handle_edge_names_types<type>(in, S, src, dest, u, v);
+        if(u == -1 || v == -1) {
+            // Prevents batch update from trying to insert this edge
+            in.set_result(-1);
+        }
+    }
+
+    if (batch.make_undirected())
+    {
+        stinger_batch_incr_edge_pairs<EdgeInsertionAdapter>(
+                S, batch.mutable_insertions()->begin(), batch.mutable_insertions()->end());
+    } else {
+        stinger_batch_incr_edges<EdgeInsertionAdapter>(
+                S, batch.mutable_insertions()->begin(), batch.mutable_insertions()->end());
+    }
+
+    OMP("omp parallel for")
+    for (size_t i = 0; i < batch.insertions_size(); i++)
+    {
+        EdgeInsertion & in = *batch.mutable_insertions(i);
+        if (in.result() == -1)
+        {
+            switch (type)
+            {
+                case NUMBERS_ONLY:
+                    LOG_E_A("Error inserting edge <%ld, %ld>", in.source(), in.destination());
+                    break;
+                case STRINGS_ONLY:
+                    LOG_E_A("Error inserting edge <%s, %s>", in.source_str().c_str(), in.destination_str().c_str());
+                    break;
+                case MIXED:
+                    LOG_E_A("Error inserting edge <%ld - %s, %ld - %s>",
+                        in.source(), in.source_str().c_str(), in.destination(), in.destination_str().c_str());
+                    break;
+                default:
+                    abort ();
+            }
+        } else if (type == NUMBERS_ONLY &&
+                   StingerServerState::get_server_state().convert_numbers_only_to_strings())
+        {
+            char * name = NULL;
+            uint64_t name_len = 0;
+            if(-1 != stinger_mapping_physid_direct(S, in.source(), &name, &name_len))
+                in.set_source_str(name, name_len);
+            else
+                in.set_source_str("");
+
+            name = NULL;
+            name_len = 0;
+            if(-1 != stinger_mapping_physid_direct(S, in.destination(), &name, &name_len))
+                in.set_destination_str(name, name_len);
+            else
+                in.set_destination_str("");
+        }
+    }
+}
+
+
+template <int64_t type>
+void process_deletions(stinger_t * S, StingerBatch & batch){
+
+    OMP("omp parallel for")
+    for(size_t d = 0; d < batch.deletions_size(); d++)
+    {
+        EdgeDeletion & del = *batch.mutable_deletions(d);
+        // Look up src/dst ID from string, if necessary
+        int64_t u, v;
+        switch(type)
+        {
+            case NUMBERS_ONLY:
+            {
+                u = del.source();
+                v = del.destination();
+            } break;
+            case STRINGS_ONLY:
+            {
+                std::string src, dest;
+                src_string (del, src);
+                dest_string (del, dest);
+                u = stinger_mapping_lookup(S, src.c_str(), src.length());
+                v = stinger_mapping_lookup(S, dest.c_str(), dest.length());
+            } break;
+            case MIXED:
+            {
+                std::string src, dest;
+                if (del.has_source()) {
+                    u = del.source();
+                    char * name = NULL;
+                    uint64_t name_len = 0;
+                    if(-1 != stinger_mapping_physid_direct(S, del.source(), &name, &name_len))
+                        del.set_source_str(name, name_len);
+                    else
+                        del.set_source_str("");
+                } else {
+                    src_string (del, src);
+                    u = stinger_mapping_lookup(S, src.c_str(), src.length());
+                    if(u != -1) del.set_source(u);
+                }
+
+                if (del.has_destination()) {
+                    v = del.destination();
+                    char * name = NULL;
+                    uint64_t name_len = 0;
+                    if(-1 != stinger_mapping_physid_direct(S, del.destination(), &name, &name_len))
+                        del.set_destination_str(name, name_len);
+                    else
+                        del.set_destination_str("");
+                } else {
+                    dest_string (del, dest);
+                    v = stinger_mapping_lookup(S, dest.c_str(), dest.length());
+                    if(v != -1) del.set_destination(v);
+                }
+            } break;
+            default:
+                abort ();
+        }
+
+        if(u != -1 && v != -1) {
+            // Do the deletion
+            if(batch.make_undirected()) {
+                del.set_result(stinger_remove_edge_pair(S, del.type(), del.source(), del.destination()));
+            } else {
+                del.set_result(stinger_remove_edge(S, del.type(), del.source(), del.destination()));
+            }
+            if (del.result() == -1) {
+                switch (type)
+                {
+                    case NUMBERS_ONLY:
+                        LOG_E_A("Error removing edge <%ld, %ld>", del.source(), del.destination());
+                        break;
+                    case STRINGS_ONLY:
+                        LOG_E_A("Error removing edge <%s, %s>", del.source_str().c_str(), del.destination_str().c_str());
+                        break;
+                    case MIXED:
+                        LOG_E_A("Error removing edge <%ld - %s, %ld - %s>",
+                                u, del.source_str().c_str(), v, del.destination_str().c_str());
+                        break;
+                    default:
+                        abort ();
+                }
+            } else if (type == NUMBERS_ONLY &&
+                       StingerServerState::get_server_state().convert_numbers_only_to_strings())
+            {
+                char * name = NULL;
+                uint64_t name_len = 0;
+                if(-1 != stinger_mapping_physid_direct(S, del.source(), &name, &name_len))
+                    del.set_source_str(name, name_len);
+                else
+                    del.set_source_str("");
+
+                name = NULL;
+                name_len = 0;
+                if(-1 != stinger_mapping_physid_direct(S, del.destination(), &name, &name_len))
+                    del.set_destination_str(name, name_len);
+                else
+                    del.set_destination_str("");
+            }
+        }
+    }
+}
+
+template <int64_t type>
+void process_vertex_updates(stinger_t * S, StingerBatch & batch){
+    OMP("omp for")
+    for(size_t d = 0; d < batch.vertex_updates_size(); d++) {
+        VertexUpdate & vup = *batch.mutable_vertex_updates(d);
+        handle_vertex_names_types<type>(vup, S);
+    }
+}
+
 /**
  * @brief Inserts and removes the edges contained in a batch.
  *
@@ -120,252 +317,28 @@ handle_edge_names_types(EdgeInsertion & in, stinger_t * S, std::string & src, st
  *
  * @return 0 on success.
  */
-  int
+int
 process_batch(stinger_t * S, StingerBatch & batch)
 {
-  StingerServerState & server_state = StingerServerState::get_server_state();
-  min_batch_ts = std::numeric_limits<int64_t>::max();
-  max_batch_ts = std::numeric_limits<int64_t>::min();
-
-#define TS(ea_) do { const int64_t ts = (ea_).time(); if (ts > mxts) mxts = ts; if (ts < mnts) mnts = ts; } while (0)
-
-  OMP("omp parallel") {
-    int64_t mxts = 0, mnts = std::numeric_limits<int64_t>::max();
-    std::string src, dest; /* Thread-local buffers */
     switch (batch.type ()) {
-
-      case NUMBERS_ONLY: {
-	if(server_state.convert_numbers_only_to_strings()) {
-	  OMP("omp for")
-	    for (size_t i = 0; i < batch.insertions_size(); i++) {
-	      EdgeInsertion & in = *batch.mutable_insertions(i);
-	      int64_t u, v;
-	      TS(in);
-	      handle_edge_names_types<NUMBERS_ONLY>(in, S, src, dest, u, v);
-	      if(batch.make_undirected()) {
-		in.set_result(stinger_incr_edge_pair(S, in.type(), in.source(), in.destination(), in.weight(), in.time()));
-	      } else {
-		in.set_result(stinger_incr_edge(S, in.type(), in.source(), in.destination(), in.weight(), in.time()));
-	      }
-	      if(in.result() == -1) {
-		LOG_E_A("Error inserting edge <%ld, %ld>", in.source(), in.destination());
-	      } else {
-		char * name = NULL;
-		uint64_t name_len = 0;
-		if(-1 != stinger_mapping_physid_direct(S, in.source(), &name, &name_len))
-		  in.set_source_str(name, name_len);
-		else
-		  in.set_source_str("");
-
-		name = NULL;
-		name_len = 0;
-		if(-1 != stinger_mapping_physid_direct(S, in.destination(), &name, &name_len))
-		  in.set_destination_str(name, name_len);
-		else
-		  in.set_destination_str("");
-	      }
-	    }
-
-	  OMP("omp for")
-	    for(size_t d = 0; d < batch.deletions_size(); d++) {
-	      EdgeDeletion & del = *batch.mutable_deletions(d);
-	      if(batch.make_undirected()) {
-		del.set_result(stinger_remove_edge_pair(S, del.type(), del.source(), del.destination()));
-	      } else {
-		del.set_result(stinger_remove_edge(S, del.type(), del.source(), del.destination()));
-	      }
-	      if(-1 == del.result()) {
-		LOG_E_A("Error removing edge <%ld, %ld>", del.source(), del.destination());
-	      } else {
-		char * name = NULL;
-		uint64_t name_len = 0;
-		if(-1 != stinger_mapping_physid_direct(S, del.source(), &name, &name_len))
-		  del.set_source_str(name, name_len);
-		else
-		  del.set_source_str("");
-
-		name = NULL;
-		name_len = 0;
-		if(-1 != stinger_mapping_physid_direct(S, del.destination(), &name, &name_len))
-		  del.set_destination_str(name, name_len);
-		else
-		  del.set_destination_str("");
-	      }
-	    }
-	} else {
-	  OMP("omp for")
-	    for (size_t i = 0; i < batch.insertions_size(); i++) {
-	      EdgeInsertion & in = *batch.mutable_insertions(i);
-	      int64_t u, v;
-	      TS(in);
-	      handle_edge_names_types<NUMBERS_ONLY>(in, S, src, dest, u, v);
-	      if(batch.make_undirected()) {
-		in.set_result(stinger_incr_edge_pair(S, in.type(), in.source(), in.destination(), in.weight(), in.time()));
-	      } else {
-		in.set_result(stinger_incr_edge(S, in.type(), in.source(), in.destination(), in.weight(), in.time()));
-	      }
-	      if(in.result() == -1) {
-		LOG_E_A("Error inserting edge <%ld, %ld>", in.source(), in.destination());
-	      }
-	    }
-
-	  OMP("omp for")
-	    for(size_t d = 0; d < batch.deletions_size(); d++) {
-	      EdgeDeletion & del = *batch.mutable_deletions(d);
-	      if(batch.make_undirected()) {
-		del.set_result(stinger_remove_edge_pair(S, del.type(), del.source(), del.destination()));
-	      } else {
-		del.set_result(stinger_remove_edge(S, del.type(), del.source(), del.destination()));
-	      }
-	      if(-1 == del.result()) {
-		LOG_E_A("Error removing edge <%ld, %ld>", del.source(), del.destination());
-	      }
-	    }
-	}
-
-	OMP("omp for")
-	  for(size_t d = 0; d < batch.vertex_updates_size(); d++) {
-	    VertexUpdate & vup = *batch.mutable_vertex_updates(d);
-	    handle_vertex_names_types<NUMBERS_ONLY>(vup, S);
-	  }
-      } break;
-
-      case STRINGS_ONLY:
-	OMP("omp for")
-	  for (size_t i = 0; i < batch.insertions_size(); i++) {
-	    EdgeInsertion & in = *batch.mutable_insertions(i);
-	    int64_t u, v;
-
-	    TS(in);
-	    handle_edge_names_types<STRINGS_ONLY>(in, S, src, dest, u, v);
-
-	    if(u != -1 && v != -1) {
-	      if(batch.make_undirected()) {
-		in.set_result(stinger_incr_edge_pair(S, in.type(), u, v, in.weight(), in.time()));
-	      } else {
-		in.set_result(stinger_incr_edge(S, in.type(), u, v, in.weight(), in.time()));
-	      }
-	      if(in.result() == -1) {
-	      LOG_E_A("Error inserting edge <%s, %s>", in.source_str().c_str(), in.destination_str().c_str());
-	      } else {
-		in.set_source(u); in.set_destination(v);
-	      }
-	    }
-	  }
-
-	OMP("omp for")
-	  for(size_t d = 0; d < batch.deletions_size(); d++) {
-	    EdgeDeletion & del = *batch.mutable_deletions(d);
-	    int64_t u, v;
-
-	    src_string (del, src);
-	    dest_string (del, dest);
-	    u = stinger_mapping_lookup(S, src.c_str(), src.length());
-	    v = stinger_mapping_lookup(S, dest.c_str(), dest.length());
-
-	    if(u != -1 && v != -1) {
-	      if(batch.make_undirected()) {
-		del.set_result(-1 == stinger_remove_edge_pair(S, del.type(), u, v));
-	      } else {
-		del.set_result(-1 == stinger_remove_edge(S, del.type(), u, v));
-	      }
-	      if(del.result() == -1) {
-		LOG_E_A("Error removing edge <%s, %s>", del.source_str().c_str(), del.destination_str().c_str());
-	      } else {
-		del.set_source(u); del.set_destination(v);
-	      }
-	    }
-	  }
-
-	OMP("omp for")
-	  for(size_t d = 0; d < batch.vertex_updates_size(); d++) {
-	    VertexUpdate & vup = *batch.mutable_vertex_updates(d);
-	    handle_vertex_names_types<STRINGS_ONLY>(vup, S);
-	  }
-	break;
-
-      case MIXED:
-	OMP("omp for")
-	  for (size_t i = 0; i < batch.insertions_size(); i++) {
-	    EdgeInsertion & in = *batch.mutable_insertions(i);
-	    int64_t u = -1, v = -1;
-	    TS(in);
-	    handle_edge_names_types<MIXED>(in, S, src, dest, u, v);
-	    if(u != -1 && v != -1) {
-	      if(batch.make_undirected()) {
-		in.set_result(stinger_incr_edge_pair(S, in.type(), u, v, in.weight(), in.time()));
-	      } else {
-		in.set_result(stinger_incr_edge(S, in.type(), u, v, in.weight(), in.time()));
-	      }
-	      if(in.result() == -1) {
-		LOG_E_A("Error inserting edge <%ld - %s, %ld - %s>", u, in.source_str().c_str(), v, 
-			in.destination_str().c_str());
-	      }
-	    }
-	  }
-
-	OMP("omp for")
-	  for(size_t d = 0; d < batch.deletions_size(); d++) {
-	    EdgeDeletion & del = *batch.mutable_deletions(d);
-	    int64_t u, v;
-
-	    if (del.has_source()) {
-	      u = del.source();
-	      char * name = NULL;
-	      uint64_t name_len = 0;
-	      if(-1 != stinger_mapping_physid_direct(S, del.source(), &name, &name_len))
-		del.set_source_str(name, name_len);
-	      else
-		del.set_source_str("");
-	    } else {
-	      src_string (del, src);
-	      u = stinger_mapping_lookup(S, src.c_str(), src.length());
-	      if(u != -1) del.set_source(u);
-	    }
-
-	    if (del.has_destination()) {
-	      v = del.destination();
-	      char * name = NULL;
-	      uint64_t name_len = 0;
-	      if(-1 != stinger_mapping_physid_direct(S, del.destination(), &name, &name_len))
-		del.set_destination_str(name, name_len);
-	      else
-		del.set_destination_str("");
-	    } else {
-	      dest_string (del, dest);
-	      v = stinger_mapping_lookup(S, dest.c_str(), dest.length());
-	      if(v != -1) del.set_destination(v);
-	    }
-
-	    if(u != -1 && v != -1) {
-	      if(batch.make_undirected()) {
-		del.set_result(stinger_remove_edge_pair(S, del.type(), u, v));
-	      } else {
-		del.set_result(stinger_remove_edge(S, del.type(), u, v));
-	      }
-	      if(del.result() == -1) {
-		LOG_E_A("Error removing edge <%ld - %s, %ld - %s>", u, del.source_str().c_str(), v, 
-			del.destination_str().c_str());
-	      }
-	    }
-	  }
-
-	OMP("omp for")
-	  for(size_t d = 0; d < batch.vertex_updates_size(); d++) {
-	    VertexUpdate & vup = *batch.mutable_vertex_updates(d);
-	    handle_vertex_names_types<MIXED>(vup, S);
-	  }
-	break;
-
-      default:
-	abort ();
+        case NUMBERS_ONLY:
+            process_insertions<NUMBERS_ONLY>(S, batch);
+            process_deletions<NUMBERS_ONLY>(S, batch);
+            process_vertex_updates<NUMBERS_ONLY>(S, batch);
+            break;
+        case STRINGS_ONLY:
+            process_insertions<STRINGS_ONLY>(S, batch);
+            process_deletions<STRINGS_ONLY>(S, batch);
+            process_vertex_updates<STRINGS_ONLY>(S, batch);
+            break;
+        case MIXED:
+            process_insertions<MIXED>(S, batch);
+            process_deletions<MIXED>(S, batch);
+            process_vertex_updates<MIXED>(S, batch);
+            break;
+        default:
+            abort();
     }
 
-    OMP("omp critical") {
-      if (mxts > max_batch_ts) max_batch_ts = mxts;
-      if (mnts < min_batch_ts) min_batch_ts = mnts;
-    }
-  }
-
-  return 0;
+    return 0;
 }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -20,6 +20,17 @@ target_link_libraries(stinger_core_test stinger_core gtest)
 
 #================================
 
+set(_stinger_batch_test_sources
+  stinger_batch_test/stinger_batch_test.cpp
+  stinger_batch_test/stinger_batch_test.h
+)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/stinger_batch_test)
+add_executable(stinger_batch_test ${_stinger_batch_test_sources})
+target_link_libraries(stinger_batch_test stinger_core gtest)
+
+#================================
+
 set(_stinger_physmap_test_sources
   stinger_physmap_test/stinger_physmap_test.cpp
   stinger_physmap_test/stinger_physmap_test.h

--- a/src/tests/stinger_batch_test/stinger_batch_test.cpp
+++ b/src/tests/stinger_batch_test/stinger_batch_test.cpp
@@ -1,0 +1,313 @@
+#include "stinger_batch_test.h"
+extern "C" {
+  #include "stinger_core/xmalloc.h"
+  #include "stinger_core/stinger_traversal.h"
+  #include "stinger_core/stinger_atomics.h"
+}
+#include "stinger_core/stinger_batch_insert.h"
+
+#include <vector>
+
+struct update {
+    int64_t type;
+    int64_t source;
+    int64_t destination;
+    int64_t weight;
+    int64_t time;
+    int64_t result;
+    static int64_t get_type(const update &u) { return u.type; }
+    static void set_type(update &u, int64_t v) { u.type = v; }
+    static int64_t get_source(const update &u) { return u.source; }
+    static void set_source(update &u, int64_t v) { u.source = v; }
+    static int64_t get_dest(const update &u) { return u.destination; }
+    static void set_dest(update &u, int64_t v) { u.destination = v; }
+    static int64_t get_weight(const update &u) { return u.weight; }
+    static int64_t get_time(const update &u) { return u.time; }
+    static int64_t get_result(const update& u) { return u.result; }
+    static void set_result(update &u, int64_t v) { u.result = v; }
+};
+
+typedef std::vector<update>::iterator update_iterator;
+
+class StingerBatchTest : public ::testing::Test {
+protected:
+  virtual void SetUp() {
+    stinger_config_t stinger_config;
+    stinger_config.nv = 1<<13;
+    stinger_config.nebs = 1<<16;
+    stinger_config.netypes = 3;
+    stinger_config.nvtypes = 2;
+    stinger_config.memory_size = 1<<30;
+    S = stinger_new_full(&stinger_config);
+  }
+
+  virtual void TearDown() {
+    stinger_free_all(S);
+  }
+
+  struct stinger_config_t * stinger_config;
+  struct stinger * S;
+};
+
+TEST_F(StingerBatchTest, single_insertion) {
+    int64_t total_edges = 0;
+
+    // Create batch to insert
+    std::vector<update> updates;
+    update u = {
+        0, // type
+        4, // source,
+        5, // destination
+        1, // weight
+        100, // time
+        0 // result
+    };
+    updates.push_back(u);
+    stinger_batch_incr_edges<update>(S, updates.begin(), updates.end());
+
+    for (update_iterator u = updates.begin(); u != updates.end(); ++u)
+    {
+        EXPECT_EQ(u->result, 1);
+    }
+
+    int64_t num_edges = 0;
+    STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, 4){
+        EXPECT_EQ(STINGER_EDGE_DEST, 5);
+        ++num_edges;
+    }STINGER_FORALL_OUT_EDGES_OF_VTX_END();
+
+    EXPECT_EQ(stinger_outdegree_get(S, 4), 1);
+    EXPECT_EQ(stinger_indegree_get(S, 5), 1);
+
+    EXPECT_EQ(num_edges, 1);
+
+    int64_t consistency = stinger_consistency_check(S,S->max_nv);
+    EXPECT_EQ(consistency,0);
+}
+
+
+TEST_F(StingerBatchTest, simple_batch_insertion) {
+    // Create batch to insert
+    std::vector<update> updates;
+    for (int i = 0; i < 2; ++i)
+    {
+        update u = {
+            0, // type
+            i, // source
+            i+1, // destination
+            1, // weight
+            i*100, // time
+            0 // result
+        };
+        updates.push_back(u);
+    }
+
+    stinger_batch_incr_edges<update>(S, updates.begin(), updates.end());
+
+    int64_t consistency = stinger_consistency_check(S,S->max_nv);
+    EXPECT_EQ(consistency,0);
+
+    for (update_iterator u = updates.begin(); u != updates.end(); ++u)
+    {
+        EXPECT_EQ(u->result, 1);
+    }
+
+    for (int i = 0; i < 2; ++i){
+        int64_t num_edges = 0;
+        STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, i){
+            EXPECT_EQ(STINGER_EDGE_DEST, i+1);
+            ++num_edges;
+        }STINGER_FORALL_OUT_EDGES_OF_VTX_END();
+        EXPECT_EQ(num_edges, 1);
+    }
+
+    EXPECT_EQ(stinger_outdegree_get(S, 0), 1);
+    EXPECT_EQ(stinger_indegree_get(S, 0), 0);
+
+    EXPECT_EQ(stinger_outdegree_get(S, 1), 1);
+    EXPECT_EQ(stinger_indegree_get(S, 1), 1);
+
+    EXPECT_EQ(stinger_outdegree_get(S, 2), 0);
+    EXPECT_EQ(stinger_indegree_get(S, 2), 1);
+
+}
+
+TEST_F(StingerBatchTest, batch_insertion) {
+    int64_t consistency;
+
+    // Create batch to insert
+    std::vector<update> updates;
+    for (int i=0; i < 100; i++) {
+        int64_t timestamp = i+1;
+        for (int j=i+1; j < 100; j++) {
+            update u = {
+                0, // type
+                i, // source
+                j, // destination
+                1, // weight
+                timestamp, // time
+                0, // result
+            };
+            updates.push_back(u);
+        }
+    }
+
+    // Do the updates
+    stinger_batch_incr_edges<update>(S, updates.begin(), updates.end());
+
+    consistency = stinger_consistency_check(S,S->max_nv);
+    EXPECT_EQ(consistency,0);
+
+    // Make sure all edges were detected as "new"
+    for (update_iterator u = updates.begin(); u != updates.end(); ++u)
+    {
+        EXPECT_EQ(u->result, 1);
+    }
+
+    // Reset return codes so we can reuse this batch
+    OMP("omp parallel for")
+    for (update_iterator u = updates.begin(); u < updates.end(); ++u) { u->result = 0; }
+
+    // Insert same batch again
+    stinger_batch_incr_edges<update>(S, updates.begin(), updates.end());
+
+    consistency = stinger_consistency_check(S,S->max_nv);
+    EXPECT_EQ(consistency,0);
+
+    // Make sure all edges were detected as "updated"
+    for (update_iterator u = updates.begin(); u != updates.end(); ++u)
+    {
+        EXPECT_EQ(u->result, 0);
+    }
+
+    // Make sure all edge weights were incremented properly
+    STINGER_FORALL_EDGES_OF_ALL_TYPES_BEGIN(S) {
+        EXPECT_EQ(STINGER_EDGE_WEIGHT, 2);
+    }STINGER_FORALL_EDGES_OF_ALL_TYPES_END();
+
+    for (int i=0; i < 100; i++) {
+        EXPECT_EQ(stinger_outdegree_get(S, i), 99 - i);
+    }
+}
+
+TEST_F(StingerBatchTest, duplicate_batch_insertion) {
+    int64_t consistency;
+
+    // Create batch to insert
+    std::vector<update> updates;
+
+    const int num_dupes = 10;
+    int total_weight_per_edge = 0;
+    int64_t num_edges;
+    for (int d=0; d < num_dupes; ++d) {
+        num_edges = 0;
+        for (int i=0; i < 100; i++) {
+            for (int j=i+1; j < 100; j++) {
+                update u = {
+                    0, // type
+                    i, // source
+                    j, // destination
+                    d, // weight
+                    d, // time
+                    0  // result
+                };
+                updates.push_back(u);
+                num_edges++;
+            }
+        }
+        total_weight_per_edge += d;
+    }
+
+    // Do the updates
+    stinger_batch_incr_edges<update>(S, updates.begin(), updates.end());
+
+    consistency = stinger_consistency_check(S,S->max_nv);
+    EXPECT_EQ(consistency,0);
+
+    // Only one update for each edge should return as "added", the rest should indicate "updated"
+    int64_t num_inserts = 0;
+    for (update_iterator u = updates.begin(); u < updates.end(); ++u)
+    {
+        if (u->result == 1) { ++num_inserts; }
+    }
+    EXPECT_EQ(num_inserts, num_edges);
+
+    // Weight should be sum of all updates
+    STINGER_FORALL_EDGES_OF_ALL_TYPES_BEGIN(S) {
+        EXPECT_EQ(STINGER_EDGE_WEIGHT, total_weight_per_edge);
+    }STINGER_FORALL_EDGES_OF_ALL_TYPES_END();
+
+    for (int i=0; i < 100; i++) {
+        EXPECT_EQ(stinger_outdegree_get(S, i), 99 - i);
+    }
+}
+
+TEST_F(StingerBatchTest, undirected_batch_insertion) {
+    // Create batch to insert
+    std::vector<update> updates;
+    for (int i=0; i < 100; i++) {
+        update u = {
+            0, // type
+            i, // source
+            i+100, // destination
+            1, // weight
+            0, // time
+            0, // result
+        };
+        updates.push_back(u);
+    }
+
+    // Do the updates
+    stinger_batch_incr_edge_pairs<update>(S, updates.begin(), updates.end());
+
+    int64_t consistency = stinger_consistency_check(S,S->max_nv);
+    EXPECT_EQ(consistency,0);
+
+    // Check to make sure we actually inserted edges in both directions
+    for (int i=0; i < 200; i++) {
+        EXPECT_EQ(stinger_outdegree_get(S, i), 1);
+    }
+}
+
+TEST_F(StingerBatchTest, typed_batch_insertion) {
+    // Create batch to insert
+    std::vector<update> updates;
+    for (int i=0; i < 100; i++) {
+        for (int type = 0; type < S->max_netypes; type++) {
+            update u = {
+                type, // type
+                i, // source
+                i+100, // destination
+                1, // weight
+                0, // time
+                0, // result
+            };
+            updates.push_back(u);
+        }
+    }
+
+    // Do the updates
+    stinger_batch_incr_edges<update>(S, updates.begin(), updates.end());
+
+    int64_t consistency = stinger_consistency_check(S,S->max_nv);
+    EXPECT_EQ(consistency,0);
+
+    // Check to make sure the edges were inserted with the correct types
+    for (int type = 0; type < S->max_netypes; type++) {
+        int num_edges = 0;
+        STINGER_FORALL_EDGES_BEGIN(S, type){
+            num_edges += 1;
+        } STINGER_FORALL_EDGES_END();
+
+        EXPECT_EQ(num_edges, 100);
+    }
+
+}
+
+
+int
+main (int argc, char *argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/tests/stinger_batch_test/stinger_batch_test.h
+++ b/src/tests/stinger_batch_test/stinger_batch_test.h
@@ -1,0 +1,12 @@
+#ifndef STINGER_BATCH_TEST_H_
+#define STINGER_BATCH_TEST_H_
+
+extern "C" {
+  #include "stinger_core/stinger.h"
+  #include "stinger_core/stinger_shared.h"
+}
+
+#include "gtest/gtest.h"
+
+
+#endif /* STINGER_BATCH_TEST_H_ */


### PR DESCRIPTION
## Summary
Provides a new family of functions for inserting an entire batch of edge updates into stinger at once. Because they perform multiple updates for each edge list traversal, these functions can be much faster (~10x) than the current implementation, which traverses the edge list at least once for each update. 

## Algorithm Overview
1. Sort the list of edge updates by source vertex ID
2. Each thread grabs a sub-list of updates for a single source vertex ID and walks that vertex's edge list
3. For each edge encountered, it performs a binary search on its sublist for any matching updates. Empty slots are filled with the next available edge in the list.

## API
The new functions are prefixed with `stinger_batch_`, and their functionality corresponds to the existing functions for inserting edges:
- `stinger_insert_edge` -> `stinger_batch_insert_edges`
- `stinger_incr_edge` -> `stinger_batch_incr_edges`
- `stinger_insert_edge_pair` -> `stinger_batch_insert_edge_pairs`
- `stinger_incr_edge` -> `stinger_batch_incr_edge_pairs`

The functions accept a pair of [iterators](http://en.cppreference.com/w/cpp/concept/RandomAccessIterator) to the range of updates to perform, which will be sorted in-place. The caller must also supply a set of adapter functions for getting/setting the source, destination, weight, type, and result code for an edge update as a template parameter. This design allows the functions to be independent of the underlying edge update type (e.g. `EdgeInsertion` or `stinger_edge_update`)

## Integration
The stinger batch server has been upgraded to use the new functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingergraph/stinger/208)
<!-- Reviewable:end -->
