### PR TITLE
Fix deadlock in edge block update due to mistaken assumption.

### DIFF
--- a/lib/stinger_core/src/stinger.c
+++ b/lib/stinger_core/src/stinger.c
@@ -1047,12 +1047,8 @@ update_edge_data_and_direction (struct stinger * S, struct stinger_eb *eb,
     /* is this a new edge */
     if (e->neighbor < 0 || index >= eb->high) {
       e->neighbor = neighbor | direction;
-      /* only edge in block? - assuming we have block effectively locked */
-      if(stinger_int64_fetch_add(&eb->numEdges, 1) == 0) {
-        eb->smallStamp = ts;
-        eb->largeStamp = ts;
-      }
       /* register new edge */
+      stinger_int64_fetch_add(&eb->numEdges, 1);
       if (direction & STINGER_EDGE_DIRECTION_OUT) { // This guarantees we don't add it twice      
         stinger_outdegree_increment_atomic(S, eb->vertexID, 1);
       } else if (direction & STINGER_EDGE_DIRECTION_IN) {        


### PR DESCRIPTION
When incrementing numEdges for an edge block, usually a 0->1 transition means that we are adding the first edge to a brand-new block. So the old code wrote to smallStamp without synchronizing, assuming that no other thread could reach the block.

But a 0->1 transition for numEdges could also mean that all edges were deleted from the block previously.
In this case we may write to smallStamp inside [another thread's critical section](https://github.com/stingergraph/stinger/blob/c5ca38b19212ed2c8805b0bb26b2a3562dc763d3/lib/stinger_core/src/stinger.c#L1090-L1098), causing a deadlock.

There's actually no need for a special case here. new_eb() initializes smallStamp/largeStamp to INT64_MAX/INT64_MIN, so the generic code for updating the timestamps will work even when the block is new.