### PR TITLE
Added missing <algorithm> includes.

### DIFF
--- a/src/clients/tools/json_rpc_server/src/array_to_json_monolithic.cpp
+++ b/src/clients/tools/json_rpc_server/src/array_to_json_monolithic.cpp
@@ -2,6 +2,7 @@
 #include "json_rpc.h"
 #include "stinger_core/xmalloc.h"
 #include "rapidjson/document.h"
+#include <algorithm>
 
 #define LOG_AT_W  /* warning only */
 #include "stinger_core/stinger_error.h"

--- a/src/server/inc/server.h
+++ b/src/server/inc/server.h
@@ -6,6 +6,7 @@ extern "C" {
 }
 #include "stinger_net/proto/stinger-batch.pb.h"
 #include "stinger_net/send_rcv.h"
+#include <algorithm>
 
 using namespace gt::stinger;
 


### PR DESCRIPTION
This is needed to fix the build on gcc 5.4.0. Perhaps older versions just included the header implicitly?