### PR TITLE
Add external protobuf install to includes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ if (${PROTOBUF_FOUND})
   add_library(_protobuf_lite_library STATIC IMPORTED)
   add_dependencies(_protobuf_lite_library protobuf)
   set_target_properties(_protobuf_lite_library PROPERTIES IMPORTED_LOCATION ${PROTOBUF_LITE_LIBRARY})
+
+  include_directories("${PROTOBUF_INCLUDE_DIR}")
 # Download and build it ourselves
 else ()
   ExternalProject_Add(protobuf


### PR DESCRIPTION
A previous patch (#185) allowed CMake to use an installed protobuf instead of building from source. However this would fail if protobuf was not installed in a system directory that was already on the include path.