### PR TITLE
Fix full/empty bit semantics for architectures with weak memory ordering (POWER8).

### DIFF
--- a/lib/stinger_core/CMakeLists.txt
+++ b/lib/stinger_core/CMakeLists.txt
@@ -8,6 +8,7 @@ set(sources
 	src/stinger_shared.c
 	src/stinger_vertex.c
 	src/xmalloc.c
+	src/x86_full_empty.c
 )
 set(headers
 	inc/core_util.h
@@ -24,9 +25,6 @@ set(headers
 	inc/x86_full_empty.h
 	inc/xmalloc.h
 )
-set(unoptimized_sources
-	src/x86_full_empty.c
-)
 
 set(config
 	stinger_names.h
@@ -39,6 +37,5 @@ include_directories("${CMAKE_BINARY_DIR}/include/stinger_core")
 include_directories("${CMAKE_BINARY_DIR}/include/stinger_utils")
 
 set_source_files_properties(${config} PROPERTIES GENERATED TRUE)
-set_source_files_properties(${unoptimized_sources} PROPERTIES COMPILE_FLAGS -O0)
-add_library(stinger_core SHARED ${sources} ${unoptimized_sources} ${headers} ${config})
+add_library(stinger_core SHARED ${sources} ${headers} ${config})
 target_link_libraries(stinger_core compat)

--- a/lib/stinger_core/inc/stinger_atomics.h
+++ b/lib/stinger_core/inc/stinger_atomics.h
@@ -9,6 +9,7 @@ extern "C" {
 
 #include "stinger.h"
 
+static inline void stinger_memory_barrier();
 static inline int stinger_int_fetch_add (int *, int);
 static inline int64_t stinger_int64_fetch_add (int64_t *, int64_t);
 static inline uint64_t stinger_uint64_fetch_add (uint64_t *, uint64_t);
@@ -26,6 +27,12 @@ static inline void *stinger_ptr_cas (void **, void *, void *);
 
 #if defined(__GNUC__)||defined(__INTEL_COMPILER)
 /* {{{ GCC / ICC defs */
+void
+stinger_memory_barrier()
+{
+  __sync_synchronize();
+}
+
 int
 stinger_int_fetch_add (int *x, int i)
 {
@@ -87,6 +94,12 @@ stinger_int64_cas (int64_t * x, int64_t origx, int64_t newx)
 /* }}} */
 #elif defined(__xlc__)
 /* {{{ XLC defs */
+void
+stinger_memory_barrier()
+{
+  __sync_synchronize();
+}
+
 int
 stinger_int_fetch_add (int *x, int i)
 {
@@ -153,6 +166,11 @@ stinger_int64_cas (int64_t * x, int64_t origx, int64_t newx)
 #elif !defined(_OPENMP)
 #warning "Assuming no parallel / concurrent operations necessary."
 /* {{{ Not concurrent */
+void
+stinger_memory_barrier()
+{
+}
+
 int
 stinger_int_fetch_add (int *v, int x)
 {

--- a/lib/stinger_core/inc/x86_full_empty.h
+++ b/lib/stinger_core/inc/x86_full_empty.h
@@ -27,19 +27,19 @@ extern "C" {
 #define MARKER UINT64_MAX
 
 uint64_t 
-readfe(uint64_t * v);
+readfe(volatile uint64_t * v);
 
 uint64_t
-writeef(uint64_t * v, uint64_t new_val);
+writeef(volatile uint64_t * v, uint64_t new_val);
 
 uint64_t
-readff(uint64_t * v);
+readff(volatile uint64_t * v);
 
 uint64_t
-writeff(uint64_t * v, uint64_t new_val);
+writeff(volatile uint64_t * v, uint64_t new_val);
 
 uint64_t
-writexf(uint64_t * v, uint64_t new_val);
+writexf(volatile uint64_t * v, uint64_t new_val);
 
 #ifdef __cplusplus
 }

--- a/lib/stinger_core/src/x86_full_empty.c
+++ b/lib/stinger_core/src/x86_full_empty.c
@@ -1,13 +1,10 @@
-/* x86 Emulation of Full Empty Bits Using atomic check-and-swap.
+/* Emulation of Full Empty Bits Using atomic check-and-swap.
  *
  * NOTES:
  * - Using these functions means that the MARKER value defined
  *   below must be reserved in your application and CANNOT be
  *   considered a normal value.  Feel free to change the value to
  *   suit your application.
- * - Do not compile this file with optimization.  There are loops
- *   that do not make sense in a serial context.  The compiler will
- *   optimize them out.
  * - Improper use of these functions can and will result in deadlock.
  *
  * author: rmccoll3@gatech.edu

--- a/lib/stinger_core/src/x86_full_empty.c
+++ b/lib/stinger_core/src/x86_full_empty.c
@@ -16,7 +16,7 @@
 #include  "x86_full_empty.h"
 
 uint64_t 
-readfe(uint64_t * v) {
+readfe(volatile uint64_t * v) {
   uint64_t val;
   while(1) {
     val = *v;
@@ -30,7 +30,7 @@ readfe(uint64_t * v) {
 }
 
 uint64_t
-writeef(uint64_t * v, uint64_t new_val) {
+writeef(volatile uint64_t * v, uint64_t new_val) {
   uint64_t val;
   while(1) {
     val = *v;
@@ -44,7 +44,7 @@ writeef(uint64_t * v, uint64_t new_val) {
 }
 
 uint64_t
-readff(uint64_t * v) {
+readff(volatile uint64_t * v) {
   uint64_t val = *v;
   while(val == MARKER) {
     val = *v;
@@ -53,7 +53,7 @@ readff(uint64_t * v) {
 }
 
 uint64_t
-writeff(uint64_t * v, uint64_t new_val) {
+writeff(volatile uint64_t * v, uint64_t new_val) {
   uint64_t val;
   while(1) {
     val = *v;
@@ -67,7 +67,7 @@ writeff(uint64_t * v, uint64_t new_val) {
 }
 
 uint64_t
-writexf(uint64_t * v, uint64_t new_val) {
+writexf(volatile uint64_t * v, uint64_t new_val) {
   *v = new_val;
   return new_val;
 }

--- a/lib/stinger_core/src/x86_full_empty.c
+++ b/lib/stinger_core/src/x86_full_empty.c
@@ -1,8 +1,8 @@
 /* x86 Emulation of Full Empty Bits Using atomic check-and-swap.
  *
  * NOTES:
- * - Using these functions means that the MARKER value defined 
- *   below must be reserved in your application and CANNOT be 
+ * - Using these functions means that the MARKER value defined
+ *   below must be reserved in your application and CANNOT be
  *   considered a normal value.  Feel free to change the value to
  *   suit your application.
  * - Do not compile this file with optimization.  There are loops
@@ -15,8 +15,9 @@
 
 #include  "x86_full_empty.h"
 
-uint64_t 
+uint64_t
 readfe(volatile uint64_t * v) {
+  stinger_memory_barrier();
   uint64_t val;
   while(1) {
     val = *v;
@@ -31,6 +32,7 @@ readfe(volatile uint64_t * v) {
 
 uint64_t
 writeef(volatile uint64_t * v, uint64_t new_val) {
+  stinger_memory_barrier();
   uint64_t val;
   while(1) {
     val = *v;
@@ -45,6 +47,7 @@ writeef(volatile uint64_t * v, uint64_t new_val) {
 
 uint64_t
 readff(volatile uint64_t * v) {
+  stinger_memory_barrier();
   uint64_t val = *v;
   while(val == MARKER) {
     val = *v;
@@ -54,6 +57,7 @@ readff(volatile uint64_t * v) {
 
 uint64_t
 writeff(volatile uint64_t * v, uint64_t new_val) {
+  stinger_memory_barrier();
   uint64_t val;
   while(1) {
     val = *v;
@@ -68,6 +72,8 @@ writeff(volatile uint64_t * v, uint64_t new_val) {
 
 uint64_t
 writexf(volatile uint64_t * v, uint64_t new_val) {
+  stinger_memory_barrier();
   *v = new_val;
+  stinger_memory_barrier();
   return new_val;
 }


### PR DESCRIPTION
The xlc compiler will optimize out the while loop in these functions even with -O0.
Use the volatile keyword to protect these accesses to shared memory instead.