### PR TITLE
compile without warnings

### DIFF
--- a/external/googletest/include/gtest/gtest.h
+++ b/external/googletest/include/gtest/gtest.h
@@ -1398,6 +1398,36 @@ GTEST_DISABLE_MSC_WARNINGS_POP_()
                             actual);
 }
 
+template <>
+inline AssertionResult CmpHelperEQ(const char* expected_expression,
+                            const char* actual_expression,
+                            const unsigned int& expected,
+                            const int& actual) {
+GTEST_DISABLE_MSC_WARNINGS_PUSH_(4389 /* signed/unsigned mismatch */)
+  if (((int) expected) == actual) {
+    return AssertionSuccess();
+  }
+GTEST_DISABLE_MSC_WARNINGS_POP_()
+
+  return CmpHelperEQFailure(expected_expression, actual_expression, expected,
+                            actual);
+}
+
+template <>
+inline AssertionResult CmpHelperEQ(const char* expected_expression,
+                            const char* actual_expression,
+                            const long long unsigned int& expected,
+                            const int& actual) {
+GTEST_DISABLE_MSC_WARNINGS_PUSH_(4389 /* signed/unsigned mismatch */)
+  if (expected == ((long long unsigned int) actual)) {
+    return AssertionSuccess();
+  }
+GTEST_DISABLE_MSC_WARNINGS_POP_()
+
+  return CmpHelperEQFailure(expected_expression, actual_expression, expected,
+                            actual);
+}
+
 // With this overloaded version, we allow anonymous enums to be used
 // in {ASSERT|EXPECT}_EQ when compiled with gcc 4, as anonymous enums
 // can be implicitly cast to BiggestInt.

--- a/lib/compat/inc/luc.h
+++ b/lib/compat/inc/luc.h
@@ -2,8 +2,8 @@
 #define _LUC_H
 
 void luc_io_init (void);
-void luc_snapin (const char*, void*, size_t);
-void luc_snapout (const char*, void*, size_t);
-void luc_stat (const char*, size_t*);
+void luc_snapin (const char*, void*, off_t);
+void luc_snapout (const char*, void*, off_t);
+void luc_stat (const char*, off_t*);
 
 #endif /* _LUC_H */

--- a/lib/compat/src/luc.cc
+++ b/lib/compat/src/luc.cc
@@ -10,9 +10,9 @@
 
 extern "C" {
 void luc_io_init (void);
-void luc_snapin (const char*, void*, size_t);
-void luc_snapout (const char*, void*, size_t);
-void luc_stat (const char*, size_t*);
+void luc_snapin (const char*, void*, off_t);
+void luc_snapout (const char*, void*, off_t);
+void luc_stat (const char*, off_t*);
 }
 
 using namespace std;
@@ -24,7 +24,7 @@ luc_io_init (void)
 
 
 static void
-read_in (const char *fname, void* buf, size_t sz)
+read_in (const char *fname, void* buf, off_t sz)
 {
   char * tmpbuf = (char *) buf;
   int fd;
@@ -34,7 +34,7 @@ read_in (const char *fname, void* buf, size_t sz)
       fname, strerror (errno));
     abort ();
   }
-  size_t bytes_read = 0;
+  off_t bytes_read = 0;
   while (bytes_read < sz) {
     int last = read(fd, tmpbuf, sz);
     bytes_read += last;
@@ -52,14 +52,14 @@ read_in (const char *fname, void* buf, size_t sz)
 
 
 void
-luc_snapin (const char *fname, void* buf, size_t sz)
+luc_snapin (const char *fname, void* buf, off_t sz)
 {
   read_in (fname, buf, sz);
 }
 
 
 static void
-write_out (const char *fname, void* buf, size_t sz)
+write_out (const char *fname, void* buf, off_t sz)
 {
   int fd;
   fd = open (fname, O_WRONLY|O_CREAT|O_TRUNC, 0666);
@@ -78,14 +78,14 @@ write_out (const char *fname, void* buf, size_t sz)
 
 
 void
-luc_snapout (const char *fname, void* buf, size_t sz)
+luc_snapout (const char *fname, void* buf, off_t sz)
 {
   write_out (fname, buf, sz);
 }
 
 
 static void
-stat_fname (const char *fname, size_t *sz)
+stat_fname (const char *fname, off_t *sz)
 {
   struct stat st;
 
@@ -99,7 +99,7 @@ stat_fname (const char *fname, size_t *sz)
 
 
 void
-luc_stat (const char *fname, size_t *sz)
+luc_stat (const char *fname, off_t *sz)
 {
     stat_fname (fname, sz);
 }

--- a/lib/int_hm_seq/inc/int_hm_seq.h
+++ b/lib/int_hm_seq/inc/int_hm_seq.h
@@ -27,16 +27,16 @@ int_hm_seq_new(int64_t size);
 int_hm_seq_t *
 int_hm_seq_free(int_hm_seq_t * ht);
 
-int_hm_seq_t * 
+void
 int_hm_seq_expand(int_hm_seq_t * ht, int64_t new_size);
 
-int_hm_seq_t * 
+void
 int_hm_seq_expand_versioned(int_hm_seq_t * ht, int64_t new_size, int64_t v);
 
 int_hm_seq_t *
 int_hm_seq_insert_versioned(int_hm_seq_t * ht, int64_t k, int64_t v);
 
-int_hm_seq_t *
+void
 int_hm_seq_insert(int_hm_seq_t * ht, int64_t k, int64_t v);
 
 int64_t *

--- a/lib/int_hm_seq/src/int-hm-seq.c
+++ b/lib/int_hm_seq/src/int-hm-seq.c
@@ -47,7 +47,7 @@ int_hm_seq_free(int_hm_seq_t * ht) {
   return NULL;
 }
 
-int_hm_seq_t * 
+void
 int_hm_seq_expand(int_hm_seq_t * ht, int64_t new_size) {
   int64_t pow = ht->size;
 
@@ -78,7 +78,7 @@ int_hm_seq_expand(int_hm_seq_t * ht, int64_t new_size) {
   *ht = tmp;
 }
 
-int_hm_seq_t * 
+void
 int_hm_seq_expand_versioned(int_hm_seq_t * ht, int64_t new_size, int64_t v) {
   int64_t pow = ht->size;
 
@@ -131,7 +131,7 @@ int_hm_seq_insert_versioned(int_hm_seq_t * ht, int64_t k, int64_t v) {
   return ht;
 }
 
-int_hm_seq_t *
+void
 int_hm_seq_insert(int_hm_seq_t * ht, int64_t k, int64_t v) {
   if(((double)(ht->elements + ht->removed)) > (0.7f) * ((double)ht->size)) {
     int_hm_seq_expand(ht, ht->size * 2);

--- a/lib/int_ht_seq/inc/int_ht_seq.h
+++ b/lib/int_ht_seq/inc/int_ht_seq.h
@@ -34,7 +34,7 @@ int_ht_seq_free_internal(int_ht_seq_t * ht);
 int_ht_seq_t *
 int_ht_seq_free(int_ht_seq_t * ht);
 
-int_ht_seq_t * 
+void
 int_ht_seq_expand(int_ht_seq_t * ht, int64_t new_size);
 
 int_ht_seq_t *

--- a/lib/int_ht_seq/src/int-ht-seq.c
+++ b/lib/int_ht_seq/src/int-ht-seq.c
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 static int64_t
 mix(int64_t n) {
@@ -69,7 +70,7 @@ int_ht_seq_free(int_ht_seq_t * ht) {
   return NULL;
 }
 
-int_ht_seq_t * 
+void
 int_ht_seq_expand(int_ht_seq_t * ht, int64_t new_size) {
   int_ht_seq_t tmp;
 
@@ -125,7 +126,7 @@ int_ht_seq_print_contents(int_ht_seq_t * ht) {
   int first = 1;
   for(uint64_t i = 0; i < ht->size; i++) {
     if(ht->keys[i] != INT_HT_SEQ_EMPTY) {
-      printf("%s%ld", first ? "" : ", ", ht->keys[i]);
+      printf("%s%" PRId64, first ? "" : ", ", ht->keys[i]);
       first = 0;
     }
   }

--- a/lib/kv_store/inc/kv_store.h
+++ b/lib/kv_store/inc/kv_store.h
@@ -184,7 +184,7 @@ kv_return_t
 kv_tracker_free_internal(kv_element_t * track);
 
 kv_return_t 
-kv_tracker_hash(kv_element_t * track, int64_t * hash);
+kv_tracker_hash(kv_element_t * track, uint64_t * hash);
 
 kv_return_t 
 kv_tracker_is(kv_element_t * a, kv_element_t * b);

--- a/lib/kv_store/src/kv_store.c
+++ b/lib/kv_store/src/kv_store.c
@@ -169,11 +169,12 @@ kv_tracker_free(kv_element_t ** track) {
   IFNULL(track, return KV_RECEIVED_NULL);
   IFNULL(*track, return KV_RECEIVED_NULL);
 
-  kv_return_t rtn = kv_tracker_free_internal(*track);
+  SAFETY(kv_return_t rtn =) kv_tracker_free_internal(*track);
   SAFETY(if(KV_SUCCESS != rtn) return rtn; );
 
   free(*track);
   SAFETY((*track) = NULL;);
+  return KV_SUCCESS;
 }
 
 kv_return_t 
@@ -192,7 +193,7 @@ kv_tracker_free_internal(kv_element_t * track) {
 }
 
 kv_return_t 
-kv_tracker_hash(kv_element_t * track, int64_t * hash) {
+kv_tracker_hash(kv_element_t * track, uint64_t * hash) {
   return kv_vector_hash(track->data.tracker.elements, hash);
 }
 
@@ -280,7 +281,7 @@ kv_return_t
 kv_element_free(kv_element_t * element) {
   IFNULL((element), return KV_RECEIVED_NULL);
 
-  kv_return_t rtn = KV_SUCCESS;
+  SAFETY(kv_return_t rtn = KV_SUCCESS;)
   switch((element)->type) {
     case KV_NONE:
     case KV_I64:
@@ -295,19 +296,19 @@ kv_element_free(kv_element_t * element) {
     } break;
 
     case KV_KV: {
-      rtn = kv_store_free_internal(element);
+      SAFETY(rtn =) kv_store_free_internal(element);
     } break;
 
     case KV_LIST: {
-      rtn = kv_list_free_internal(element);
+      SAFETY(rtn =) kv_list_free_internal(element);
     } break;
 
     case KV_VECTOR: {
-      rtn = kv_vector_free_internal(element);
+      SAFETY(rtn =) kv_vector_free_internal(element);
     } break;
 
     case KV_TRACKER: {
-      rtn = kv_tracker_free_internal(element);
+      SAFETY(rtn =) kv_tracker_free_internal(element);
     } break;
   }
   element->type = KV_NONE;
@@ -370,8 +371,6 @@ kv_return_t
 kv_element_hash(kv_element_t * a, uint64_t * hash) {
   IFNULL(*a, return KV_RECEIVED_NULL);
 
-  uint64_t out = 0;
-
   switch(a->type) {
     case KV_NONE: 
     case KV_DBL:
@@ -386,22 +385,22 @@ kv_element_hash(kv_element_t * a, uint64_t * hash) {
     } break;
 
     case KV_KV: {
-      kv_return_t rtn = kv_store_hash(a, hash);
+      SAFETY(kv_return_t rtn =) kv_store_hash(a, hash);
       SAFETY(if(KV_SUCCESS != rtn) return rtn);
     } break;
 
     case KV_LIST: {
-      kv_return_t rtn = kv_list_hash(a, hash);
+      SAFETY(kv_return_t rtn =) kv_list_hash(a, hash);
       SAFETY(if(KV_SUCCESS != rtn) return rtn);
     } break;
 
     case KV_VECTOR: {
-      kv_return_t rtn = kv_vector_hash(a, hash);
+      SAFETY(kv_return_t rtn =) kv_vector_hash(a, hash);
       SAFETY(if(KV_SUCCESS != rtn) return rtn);
     } break;
 
     case KV_TRACKER: {
-      kv_return_t rtn = kv_tracker_hash(a, hash);
+      SAFETY(kv_return_t rtn =) kv_tracker_hash(a, hash);
       SAFETY(if(KV_SUCCESS != rtn) return rtn);
     } break;
 
@@ -446,10 +445,12 @@ kv_element_print(kv_element_t * a, int64_t indent) {
       kv_list_print(a, indent);
     } break;
 
+    case KV_TRACKER:
     case KV_VECTOR: {
   /* TODO */
     } break;
   }
+  return KV_SUCCESS;
 }
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *
@@ -497,7 +498,7 @@ kv_list_free(kv_element_t ** list) {
   IFNULL(list, return KV_RECEIVED_NULL);
   IFNULL(*list, return KV_RECEIVED_NULL);
 
-  kv_return_t rtn = kv_list_free_internal(*list);
+  SAFETY(kv_return_t rtn =) kv_list_free_internal(*list);
   SAFETY(if(KV_SUCCESS != rtn) return rtn;);
 
   free(*list);
@@ -548,7 +549,7 @@ kv_list_hash(kv_element_t * list, uint64_t * hash) {
 
   kv_list_element_t * cur = list->data.list.head;
   while(cur) {
-    kv_return_t rtn = kv_element_hash(cur->data, hash);
+    SAFETY(kv_return_t rtn =) kv_element_hash(cur->data, hash);
     SAFETY(if(KV_SUCCESS != rtn) return rtn;);
     cur = cur->next;
   }
@@ -852,7 +853,7 @@ kv_vector_hash(kv_element_t * vec, uint64_t * hash) {
   IFNULL(vec, return KV_RECEIVED_NULL);
 
   for(uint64_t i = 0; i < vec->data.vec.length; i++) {
-    kv_return_t rtn = kv_element_hash(vec->data.vec.arr[i], hash);
+    SAFETY(kv_return_t rtn =) kv_element_hash(vec->data.vec.arr[i], hash);
     SAFETY(if(KV_SUCCESS != rtn) return rtn;);
   }
   
@@ -880,7 +881,6 @@ kv_vector_set(kv_element_t * vec, int64_t index, kv_element_t * val) {
 
   SAFETY(if(index >= vec->data.vec.length) return KV_OUT_OF_BOUNDS;);
 
-  kv_return_t rtn;
   if(index + 1 >= vec->data.vec.length) {
     kv_vector_resize(vec, index+1);
   }
@@ -973,7 +973,7 @@ kv_store_free_internal(kv_element_t * kv) {
 kv_return_t
 kv_store_free(kv_element_t ** kv) {
   IFNULL(kv, return KV_RECEIVED_NULL);
-  kv_return_t rtn = kv_store_free_internal(*kv);
+  SAFETY(kv_return_t rtn =) kv_store_free_internal(*kv);
   SAFETY(if(KV_SUCCESS != rtn) return rtn; );
   free(*kv);
   SAFETY(*kv = NULL; );
@@ -1026,9 +1026,9 @@ kv_store_hash(kv_element_t * kv, uint64_t * hash) {
 
   for(uint64_t i = 0; i < kv->data.kv.size; i++) {
     if(kv->data.kv.keys[i] != KV_DELETED_PTR && kv->data.kv.keys[i] != KV_NONE_PTR) {
-      kv_return_t rtn = kv_element_hash(kv->data.kv.keys[i], hash);
+      SAFETY(kv_return_t rtn =) kv_element_hash(kv->data.kv.keys[i], hash);
       SAFETY(if(KV_SUCCESS != rtn) return rtn;);
-      rtn = kv_element_hash(kv->data.kv.vals[i], hash);
+      SAFETY(rtn =) kv_element_hash(kv->data.kv.vals[i], hash);
       SAFETY(if(KV_SUCCESS != rtn) return rtn;);
     }
   }
@@ -1042,8 +1042,8 @@ kv_store_get(kv_element_t * kv, kv_element_t * key, kv_element_t ** val) {
   IFNULL(key, return KV_RECEIVED_NULL);
   IFNULL(val, return KV_RECEIVED_NULL);
 
-  int64_t index = 0;
-  kv_return_t rtn = kv_element_hash(key, &index); 
+  uint64_t index = 0;
+  SAFETY(kv_return_t rtn =) kv_element_hash(key, &index); 
   SAFETY(if(KV_SUCCESS != rtn) return rtn;);
 
   index = index & kv->data.kv.mask;
@@ -1069,12 +1069,12 @@ kv_store_set(kv_element_t * kv, kv_element_t * key, kv_element_t * val) {
   IFNULL(val, return KV_RECEIVED_NULL);
 
   if((kv->data.kv.elements + kv->data.kv.removed) > (KV_STORE_THRESHOLD * kv->data.kv.size)) {
-    kv_return_t rtn = kv_store_expand(kv);
+    SAFETY(kv_return_t rtn =) kv_store_expand(kv);
     SAFETY(if(KV_SUCCESS != rtn) return rtn);
   }
 
-  int64_t index = 0;
-  kv_return_t rtn = kv_element_hash(key, &index); 
+  uint64_t index = 0;
+  SAFETY(kv_return_t rtn =) kv_element_hash(key, &index); 
   SAFETY(if(KV_SUCCESS != rtn) return rtn;);
 
   index = index & kv->data.kv.mask;
@@ -1111,16 +1111,15 @@ kv_store_remove(kv_element_t * kv, kv_element_t * key) {
   IFNULL(key, return KV_RECEIVED_NULL);
 
   if((kv->data.kv.elements + kv->data.kv.removed) > (KV_STORE_THRESHOLD * kv->data.kv.size)) {
-    kv_return_t rtn = kv_store_expand(kv);
+    SAFETY(kv_return_t rtn =) kv_store_expand(kv);
     SAFETY(if(KV_SUCCESS != rtn) return rtn);
   }
 
-  int64_t index = 0;
-  kv_return_t rtn = kv_element_hash(key, &index); 
+  uint64_t index = 0;
+  SAFETY(kv_return_t rtn =) kv_element_hash(key, &index); 
   SAFETY(if(KV_SUCCESS != rtn) return rtn;);
 
   index = index & kv->data.kv.mask;
-  int64_t deleted_index = -1;
   while(kv->data.kv.keys[index] != KV_NONE_PTR && 
     (kv->data.kv.keys[index] == KV_DELETED_PTR || 
       kv_element_equal(key, kv->data.kv.keys[index]) != KV_EQUAL)) {
@@ -1144,12 +1143,11 @@ kv_store_contains(kv_element_t * kv, kv_element_t * key) {
   IFNULL(kv, return KV_RECEIVED_NULL);
   IFNULL(key, return KV_RECEIVED_NULL);
 
-  int64_t index = 0;
-  kv_return_t rtn = kv_element_hash(key, &index); 
+  uint64_t index = 0;
+  SAFETY(kv_return_t rtn =) kv_element_hash(key, &index); 
   SAFETY(if(KV_SUCCESS != rtn) return rtn;);
 
   index = index & kv->data.kv.mask;
-  int64_t deleted_index = -1;
   while(kv->data.kv.keys[index] != KV_NONE_PTR && 
     (kv->data.kv.keys[index] == KV_DELETED_PTR || 
       kv_element_equal(key, kv->data.kv.keys[index]) != KV_EQUAL)) {
@@ -1185,7 +1183,7 @@ kv_store_expand(kv_element_t * kv) {
     }
   }
 
-  kv_return_t rtn = kv_store_free_internal(kv);
+  SAFETY(kv_return_t rtn =) kv_store_free_internal(kv);
   SAFETY(if(KV_SUCCESS != rtn) return rtn;);
 
   *kv = tmp;
@@ -1646,7 +1644,7 @@ kv_from_ini(FILE * ini, kv_element_t * tracker, kv_element_t ** top_level) {
   string_t * cur_store_val;
   kv_element_t * cur_list;
   kv_element_t * cur_store;
-  int c;
+  int c = -1;
   int line_num = 0;
   int last_was_space = 0;
 
@@ -1700,7 +1698,7 @@ eatwhitespace:
     break;
   }
 
-eatkey:
+/*eatkey:*/
   cur_key = string_new();
   while(1) {
     switch(c) {

--- a/lib/mongo_c_driver/src/bcon.c
+++ b/lib/mongo_c_driver/src/bcon.c
@@ -44,12 +44,18 @@ bcon_token_t bcon_token(char *s) {
     switch (s[0]) {
     case ':': if (s[1] != '\0' && s[2] != '\0' && s[3] != '\0' && s[4] == '\0' &&
                       s[3] == ':' && (s[1] == '_' || s[1] == 'P' || s[1] == 'R'))
-            return Token_Typespec; break;
-    case '{': if (s[1] == '\0') return Token_OpenBrace; break;
-    case '}': if (s[1] == '\0') return Token_CloseBrace; break;
-    case '[': if (s[1] == '\0') return Token_OpenBracket; break;
-    case ']': if (s[1] == '\0') return Token_CloseBracket; break;
-    case '.': if (s[1] == '\0') return Token_End; break;
+            return Token_Typespec;
+        break;
+    case '{': if (s[1] == '\0') return Token_OpenBrace;
+        break;
+    case '}': if (s[1] == '\0') return Token_CloseBrace;
+        break;
+    case '[': if (s[1] == '\0') return Token_OpenBracket;
+        break;
+    case ']': if (s[1] == '\0') return Token_CloseBracket;
+        break;
+    case '.': if (s[1] == '\0') return Token_End;
+        break;
     }
     return Token_Default;
 }

--- a/lib/mongo_c_driver/src/mongo.c
+++ b/lib/mongo_c_driver/src/mongo.c
@@ -1510,14 +1510,14 @@ MONGO_EXPORT int mongo_create_index( mongo *conn, const char *ns, const bson *ke
 	    bson_destroy( &b );
         if( out )
             bson_init_zero(out);
-	    return MONGO_ERROR;
+        return MONGO_ERROR;
     }
     strcpy( p, ".system.indexes" );
     if ( mongo_insert( conn, idxns, &b, NULL ) != MONGO_OK) {
 	    bson_destroy( &b );
         if( out )
             bson_init_zero(out);
-	    return MONGO_ERROR;
+        return MONGO_ERROR;
     }
     bson_destroy( &b );
 

--- a/lib/mongoose/src/mongoose.c
+++ b/lib/mongoose/src/mongoose.c
@@ -3399,6 +3399,8 @@ static void handle_cgi_request(struct mg_connection *conn, const char *prog) {
   struct file fout = STRUCT_FILE_INITIALIZER;
   pid_t pid = (pid_t) -1;
 
+  ri.num_headers = 0;
+
   prepare_cgi_environment(conn, prog, &blk);
 
   // CGI must be executed in its own directory. 'dir' must point to the

--- a/lib/stinger_alg/inc/adamic_adar.h
+++ b/lib/stinger_alg/inc/adamic_adar.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-int64_t adamic_adar(const stinger_t * S, int64_t source, int64_t etype, int64_t ** candidates, double ** scores);
+int64_t adamic_adar(stinger_t * S, int64_t source, int64_t etype, int64_t ** candidates, double ** scores);
 
 #ifdef __cplusplus
 }

--- a/lib/stinger_alg/inc/community_on_demand.h
+++ b/lib/stinger_alg/inc/community_on_demand.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-int64_t community_on_demand(const stinger_t * S, int64_t ** vertices, int64_t ** partitions);
+int64_t community_on_demand(stinger_t * S, int64_t ** vertices, int64_t ** partitions);
 
 #ifdef __cplusplus
 }

--- a/lib/stinger_alg/inc/pagerank.h
+++ b/lib/stinger_alg/inc/pagerank.h
@@ -11,11 +11,11 @@
 #define DAMPINGFACTOR_DEFAULT 0.85
 #define MAXITER_DEFAULT 20
 
-int64_t page_rank_subset(stinger_t * S, int64_t NV, uint8_t * vertex_set, int64_t vertex_set_size, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter);
-int64_t page_rank_directed(stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter);
-int64_t page_rank (stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter);
-int64_t page_rank_type(stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter, int64_t type);
-int64_t page_rank_type_directed(stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter, int64_t type);
+void page_rank_subset(stinger_t * S, int64_t NV, uint8_t * vertex_set, int64_t vertex_set_size, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter);
+void page_rank_directed(stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter);
+void page_rank (stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter);
+void page_rank_type(stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter, int64_t type);
+void page_rank_type_directed(stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter, int64_t type);
 
 
 double * set_tmp_pr(double * tmp_pr_in, int64_t NV);

--- a/lib/stinger_alg/inc/streaming_connected_components.h
+++ b/lib/stinger_alg/inc/streaming_connected_components.h
@@ -57,10 +57,10 @@ void stinger_scc_release_internals(stinger_scc_internal* scc_internal);
 // Should be called before each batch update.
 void stinger_scc_reset_stats(stinger_connected_components_stats* stats);
 
-int stinger_scc_insertion(struct stinger * S, int64_t nv,  stinger_scc_internal scc_internal, 
+void stinger_scc_insertion(struct stinger * S, int64_t nv,  stinger_scc_internal scc_internal, 
 	stinger_connected_components_stats* stats, stinger_edge_update* batch,int64_t batch_size);
 
-int stinger_scc_deletion(struct stinger * S, int64_t nv,  stinger_scc_internal scc_internal, 
+void stinger_scc_deletion(struct stinger * S, int64_t nv,  stinger_scc_internal scc_internal, 
 	stinger_connected_components_stats* stats, stinger_edge_update* batch,int64_t batch_size);
 
 

--- a/lib/stinger_alg/src/adamic_adar.c
+++ b/lib/stinger_alg/src/adamic_adar.c
@@ -14,7 +14,7 @@ compare (const void * a, const void * b)
  *  when performing the analysis.  This is to account for the fact that Adamic Adar is only defined for an undirected
  *  graph.
  */
-int64_t adamic_adar(const stinger_t * S, int64_t source, int64_t etype, int64_t ** candidates, double ** scores) {
+int64_t adamic_adar(stinger_t * S, int64_t source, int64_t etype, int64_t ** candidates, double ** scores) {
   if (*candidates != NULL || *scores != NULL) {
     LOG_E("Adamic Adar output arrays should not be allocated before call.  Possible memory leak.");
   }
@@ -106,7 +106,7 @@ int64_t adamic_adar(const stinger_t * S, int64_t source, int64_t etype, int64_t 
 
   /* Allocate output array */
   output_vertices = (int64_t *) xmalloc (two_hop_size * sizeof(int64_t));
-  output_scores = (int64_t *) xmalloc (two_hop_size * sizeof(double));
+  output_scores = (double *) xmalloc (two_hop_size * sizeof(double));
 
   /* calculate the Adamic-Adar score for each vertex in level 2 */
   for (int64_t k = 0; k < two_hop_size; k++) {

--- a/lib/stinger_alg/src/community_on_demand.c
+++ b/lib/stinger_alg/src/community_on_demand.c
@@ -6,7 +6,7 @@
  *  On-demand community detection
  *
  */
-int64_t community_on_demand(const stinger_t * S, int64_t ** vertices, int64_t ** partitions) {
+int64_t community_on_demand(stinger_t * S, int64_t ** vertices, int64_t ** partitions) {
   if (*vertices != NULL || *partitions != NULL) {
     LOG_E("Community on demand output arrays should not be allocated before call.  Possible memory leak.");
   }

--- a/lib/stinger_alg/src/graph_partition.c
+++ b/lib/stinger_alg/src/graph_partition.c
@@ -92,7 +92,7 @@ graph_partition(struct stinger * S, uint64_t NV, uint64_t num_partitions, double
     }
     //TODO fix returns, what would be a good output?
     for (int64_t i = 0; i<NV; i++){
-        printf("Verticies Added %ld => %ld\n", i, partitions[i]);
+        printf("Verticies Added %" PRId64 " => %" PRId64 "\n", i, partitions[i]);
     }
 }
 

--- a/lib/stinger_alg/src/kcore.c
+++ b/lib/stinger_alg/src/kcore.c
@@ -5,7 +5,7 @@ void
 kcore_find(stinger_t *S, int64_t * labels, int64_t * counts, int64_t nv, int64_t * k_out) {
   int64_t k = 0;
 
-  for(int64_t v; v < nv; v++) {
+  for(int64_t v = 0; v < nv; v++) {
     if(stinger_outdegree_get(S,v)) {
       labels[v] = 1;
     } else {

--- a/lib/stinger_alg/src/modularity.c
+++ b/lib/stinger_alg/src/modularity.c
@@ -81,7 +81,7 @@ community_detection(stinger_t * S, int64_t NV, int64_t * partitions, int64_t max
     for (int64_t i = 0; i < NV; i++){
         partitions[i] = i;
     }
-    int64_t num_partitions = NV;
+    /*int64_t num_partitions = NV;*/
     partitions = louvain_method(S,partitions, NV, m, maxIter);
 
 }

--- a/lib/stinger_alg/src/pagerank.c
+++ b/lib/stinger_alg/src/pagerank.c
@@ -18,7 +18,7 @@ inline void unset_tmp_pr(double * tmp_pr, double * tmp_pr_in) {
     free(tmp_pr);
 }
 
-int64_t 
+void 
 page_rank_subset(stinger_t * S, int64_t NV, uint8_t * vertex_set, int64_t vertex_set_size, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter) {
   double * tmp_pr = set_tmp_pr(tmp_pr_in, NV);
 
@@ -27,7 +27,7 @@ page_rank_subset(stinger_t * S, int64_t NV, uint8_t * vertex_set, int64_t vertex
   OMP("omp parallel for")
   for (uint64_t v = 0; v < NV; v++) {
     if (vertex_set[v]) {
-      LOG_D_A("%ld - %lf\n",v,pr[v]);
+      LOG_D_A("%" PRIu64 " - %lf\n",v,pr[v]);
       STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S,v) {
         if (vertex_set[STINGER_EDGE_DEST]) {
           vtx_outdegree[v]++;
@@ -58,10 +58,10 @@ page_rank_subset(stinger_t * S, int64_t NV, uint8_t * vertex_set, int64_t vertex
     STINGER_PARALLEL_FORALL_EDGES_OF_ALL_TYPES_BEGIN(S) {
       if (vertex_set[STINGER_EDGE_DEST] && vertex_set[STINGER_EDGE_SOURCE]) {
         int64_t outdegree = vtx_outdegree[STINGER_EDGE_SOURCE];
-        int64_t count = readfe(&pr_lock[STINGER_EDGE_DEST]);
+        int64_t count = readfe((uint64_t *) &pr_lock[STINGER_EDGE_DEST]);
         tmp_pr[STINGER_EDGE_DEST] += (((double)pr[STINGER_EDGE_SOURCE]) /
           ((double) outdegree));
-        writeef(&pr_lock[STINGER_EDGE_DEST],count+1);
+        writeef((uint64_t *) &pr_lock[STINGER_EDGE_DEST],count+1);
       }
     } STINGER_PARALLEL_FORALL_EDGES_OF_ALL_TYPES_END();
 
@@ -99,13 +99,13 @@ page_rank_subset(stinger_t * S, int64_t NV, uint8_t * vertex_set, int64_t vertex
   xfree(vtx_outdegree);
 }
 
-int64_t
+void
 page_rank_directed(stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter) {
-  return page_rank(S, NV, pr, tmp_pr_in, epsilon, dampingfactor, maxiter);
+  page_rank(S, NV, pr, tmp_pr_in, epsilon, dampingfactor, maxiter);
 }
 
 // NOTE: This only works on Undirected Graphs!
-int64_t
+void
 page_rank (stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter)
 {
   double * tmp_pr = set_tmp_pr(tmp_pr_in, NV);
@@ -157,18 +157,18 @@ page_rank (stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double ep
     iter--;
   }
 
-  LOG_I_A("PageRank iteration count : %ld", iter_count);
+  LOG_I_A("PageRank iteration count : %" PRId64, iter_count);
 
   unset_tmp_pr(tmp_pr,tmp_pr_in);
 }
 
-int64_t
+void
 page_rank_type_directed(stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter, int64_t type)
 {
-  return page_rank_type(S, NV, pr, tmp_pr_in, epsilon, dampingfactor, maxiter, type);
+  page_rank_type(S, NV, pr, tmp_pr_in, epsilon, dampingfactor, maxiter, type);
 }
 
-int64_t
+void
 page_rank_type(stinger_t * S, int64_t NV, double * pr, double * tmp_pr_in, double epsilon, double dampingfactor, int64_t maxiter, int64_t type)
 {
   double * tmp_pr = set_tmp_pr(tmp_pr_in, NV);

--- a/lib/stinger_core/inc/stinger.h
+++ b/lib/stinger_core/inc/stinger.h
@@ -138,16 +138,16 @@ int stinger_edge_touch (struct stinger *, int64_t /* vtx 1 */ ,
  * INTERNAL "Objects"
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 stinger_vertices_t *
-stinger_vertices_get(const stinger_t * S);
+stinger_vertices_get(stinger_t * S);
 
 stinger_physmap_t *
-stinger_physmap_get(const stinger_t * S);
+stinger_physmap_get(stinger_t * S);
 
 stinger_names_t *
-stinger_vtype_names_get(const stinger_t * S);
+stinger_vtype_names_get(stinger_t * S);
 
 stinger_names_t *
-stinger_etype_names_get(const stinger_t * S);
+stinger_etype_names_get(stinger_t * S);
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ * 
  * VERTEX METADATA
@@ -159,13 +159,13 @@ vdegree_t
 stinger_degree_get(const stinger_t * S, vindex_t v);
 
 vdegree_t
-stinger_degree_set(const stinger_t * S, vindex_t v, vdegree_t d);
+stinger_degree_set(stinger_t * S, vindex_t v, vdegree_t d);
 
 vdegree_t
-stinger_degree_increment(const stinger_t * S, vindex_t v, vdegree_t d);
+stinger_degree_increment(stinger_t * S, vindex_t v, vdegree_t d);
 
 vdegree_t
-stinger_degree_increment_atomic(const stinger_t * S, vindex_t v, vdegree_t d);
+stinger_degree_increment_atomic(stinger_t * S, vindex_t v, vdegree_t d);
 
 /* IN DEGREE */
 
@@ -173,13 +173,13 @@ vdegree_t
 stinger_indegree_get(const stinger_t * S, vindex_t v);
 
 vdegree_t
-stinger_indegree_set(const stinger_t * S, vindex_t v, vdegree_t d);
+stinger_indegree_set(stinger_t * S, vindex_t v, vdegree_t d);
 
 vdegree_t
-stinger_indegree_increment(const stinger_t * S, vindex_t v, vdegree_t d);
+stinger_indegree_increment(stinger_t * S, vindex_t v, vdegree_t d);
 
 vdegree_t
-stinger_indegree_increment_atomic(const stinger_t * S, vindex_t v, vdegree_t d);
+stinger_indegree_increment_atomic(stinger_t * S, vindex_t v, vdegree_t d);
 
 /* OUT DEGREE */
 
@@ -187,13 +187,13 @@ vdegree_t
 stinger_outdegree_get(const stinger_t * S, vindex_t v);
 
 vdegree_t
-stinger_outdegree_set(const stinger_t * S, vindex_t v, vdegree_t d);
+stinger_outdegree_set(stinger_t * S, vindex_t v, vdegree_t d);
 
 vdegree_t
-stinger_outdegree_increment(const stinger_t * S, vindex_t v, vdegree_t d);
+stinger_outdegree_increment(stinger_t * S, vindex_t v, vdegree_t d);
 
 vdegree_t
-stinger_outdegree_increment_atomic(const stinger_t * S, vindex_t v, vdegree_t d);
+stinger_outdegree_increment_atomic(stinger_t * S, vindex_t v, vdegree_t d);
 
 /* TYPE */
 
@@ -201,20 +201,20 @@ vtype_t
 stinger_vtype_get(const stinger_t * S, vindex_t v);
 
 vtype_t
-stinger_vtype_set(const stinger_t * S, vindex_t v, vtype_t type);
+stinger_vtype_set(stinger_t * S, vindex_t v, vtype_t type);
 
 /* WEIGHT */
 vweight_t
 stinger_vweight_get(const stinger_t * S, vindex_t v);
 
 vweight_t
-stinger_vweight_set(const stinger_t * S, vindex_t v, vweight_t weight);
+stinger_vweight_set(stinger_t * S, vindex_t v, vweight_t weight);
 
 vweight_t
-stinger_vweight_increment(const stinger_t * S, vindex_t v, vweight_t weight);
+stinger_vweight_increment(stinger_t * S, vindex_t v, vweight_t weight);
 
 vweight_t
-stinger_vweight_increment_atomic(const stinger_t * S, vindex_t v, vweight_t weight);
+stinger_vweight_increment_atomic(stinger_t * S, vindex_t v, vweight_t weight);
 
 /* ADJACENCY */
 adjacency_t
@@ -225,7 +225,7 @@ stinger_adjacency_get(const stinger_t * S, vindex_t v);
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 int
-stinger_mapping_create(const stinger_t * S, const char * byte_string, uint64_t length, int64_t * vtx_out);
+stinger_mapping_create(stinger_t * S, const char * byte_string, uint64_t length, int64_t * vtx_out);
 
 vindex_t
 stinger_mapping_lookup(const stinger_t * S, const char * byte_string, uint64_t length);
@@ -244,7 +244,7 @@ stinger_mapping_nv(const stinger_t * S);
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 int
-stinger_vtype_names_create_type(const stinger_t * S, const char * name, int64_t * out);
+stinger_vtype_names_create_type(stinger_t * S, const char * name, int64_t * out);
 
 int64_t
 stinger_vtype_names_lookup_type(const stinger_t * S, const char * name);

--- a/lib/stinger_core/inc/stinger_atomics.h
+++ b/lib/stinger_core/inc/stinger_atomics.h
@@ -11,14 +11,14 @@ extern "C" {
 
 static inline void stinger_memory_barrier();
 static inline int stinger_int_fetch_add (int *, int);
-static inline int64_t stinger_int64_fetch_add (int64_t *, int64_t);
+inline int64_t stinger_int64_fetch_add (int64_t *, int64_t);
 static inline uint64_t stinger_uint64_fetch_add (uint64_t *, uint64_t);
 static inline size_t stinger_size_fetch_add (size_t *, size_t);
 
 static inline void stinger_int64_swap (int64_t *, int64_t *);
 static inline void stinger_uint64_swap (uint64_t *, uint64_t *);
 
-static inline int64_t stinger_int64_cas (int64_t *, int64_t, int64_t);
+static inline int64_t stinger_int64_cas (volatile int64_t *, int64_t, int64_t);
 /* XXX: This declaration may break aliasing, depending on how you
    interpret "void".  A pointer to nothing cannot alias anything...
    however, the absolutely correct unsigned char* is a pain to use,
@@ -39,7 +39,7 @@ stinger_int_fetch_add (int *x, int i)
   return __sync_fetch_and_add (x, i);
 }
 
-int64_t
+inline int64_t
 stinger_int64_fetch_add (int64_t * x, int64_t i)
 {
   return __sync_fetch_and_add (x, i);
@@ -86,7 +86,7 @@ stinger_ptr_cas (void **x, void *origx, void *newx)
 }
 
 int64_t
-stinger_int64_cas (int64_t * x, int64_t origx, int64_t newx)
+stinger_int64_cas (volatile int64_t * x, int64_t origx, int64_t newx)
 {
   return __sync_val_compare_and_swap (x, origx, newx);
 }
@@ -106,7 +106,7 @@ stinger_int_fetch_add (int *x, int i)
   return __fetch_and_add (x, i);
 }
 
-int64_t
+inline int64_t
 stinger_int64_fetch_add (int64_t * x, int64_t i)
 {
   return __fetch_and_addlp ((volatile unsigned long*)x, (unsigned long)i);
@@ -155,7 +155,7 @@ stinger_ptr_cas (void **x, void *origx, void *newx)
 }
 
 int64_t
-stinger_int64_cas (int64_t * x, int64_t origx, int64_t newx)
+stinger_int64_cas (volatile int64_t * x, int64_t origx, int64_t newx)
 {
   int64_t t = *x;
   __compare_and_swaplp (x, &origx, newx);
@@ -179,7 +179,7 @@ stinger_int_fetch_add (int *v, int x)
   return out;
 }
 
-int64_t
+inline int64_t
 stinger_int64_fetch_add (int64_t * v, int64_t x)
 {
   int64_t out = *v;
@@ -220,7 +220,7 @@ stinger_uint64_swap (uint64_t * a, uint64_t * b)
 }
 
 int64_t
-stinger_int64_cas (int64_t * p, int64_t v, int64_t newv)
+stinger_int64_cas (volatile int64_t * p, int64_t v, int64_t newv)
 {
   int64_t oldv = *p;
   if (v == oldv)

--- a/lib/stinger_core/inc/stinger_batch_insert.h
+++ b/lib/stinger_core/inc/stinger_batch_insert.h
@@ -412,7 +412,7 @@ protected:
             // Calculate number of updates for each range
             size_t num_updates = std::distance(begin, end);
             size_t num_ranges = omp_get_num_threads();
-            size_t updates_per_range = std::floor((double)num_updates / num_ranges);
+            int updates_per_range = std::floor((double)num_updates / num_ranges);
 
             std::vector<range> local_ranges; local_ranges.reserve(num_ranges);
             if (updates_per_range < omp_get_num_threads())

--- a/lib/stinger_core/inc/stinger_deprecated.h
+++ b/lib/stinger_core/inc/stinger_deprecated.h
@@ -58,7 +58,7 @@ stinger_remove_and_insert_batch (struct stinger * G, int64_t type,
                                  int64_t * insoff, int64_t * deloff,
                                  int64_t * act);
 void
-stinger_gather_typed_successors_serial (const struct stinger *G, int64_t type,
+stinger_gather_typed_successors_serial (struct stinger *G, int64_t type,
                                         int64_t v, size_t * outlen,
                                         int64_t * out, size_t max_outlen);
 

--- a/lib/stinger_core/inc/stinger_internal.h
+++ b/lib/stinger_core/inc/stinger_internal.h
@@ -17,7 +17,13 @@ extern "C" {
   stinger_names_t * etype_names = (stinger_names_t *)((X)->storage + (X)->etype_names_start); \
   stinger_names_t * vtype_names = (stinger_names_t *)((X)->storage + (X)->vtype_names_start); \
   uint8_t * _ETA = ((X)->storage + (X)->ETA_start); \
-  struct stinger_ebpool * ebpool = (struct stinger_ebpool *)((X)->storage + (X)->ebpool_start);
+  struct stinger_ebpool * ebpool = (struct stinger_ebpool *)((X)->storage + (X)->ebpool_start); \
+  (void) vertices; \
+  (void) physmap; \
+  (void) etype_names; \
+  (void) vtype_names; \
+  (void) _ETA; \
+  (void) ebpool;
 	  
 #define CONST_MAP_STING(X) \
   const stinger_vertices_t * vertices = (const stinger_vertices_t *)((X)->storage); \
@@ -25,7 +31,13 @@ extern "C" {
   const stinger_names_t * etype_names = (const stinger_names_t *)((X)->storage + (X)->etype_names_start); \
   const stinger_names_t * vtype_names = (const stinger_names_t *)((X)->storage + (X)->vtype_names_start); \
   const uint8_t * _ETA = ((X)->storage + (X)->ETA_start); \
-  const struct stinger_ebpool * ebpool = (const struct stinger_ebpool *)((X)->storage + (X)->ebpool_start);
+  const struct stinger_ebpool * ebpool = (const struct stinger_ebpool *)((X)->storage + (X)->ebpool_start); \
+  (void) vertices; \
+  (void) physmap; \
+  (void) etype_names; \
+  (void) vtype_names; \
+  (void) _ETA; \
+  (void) ebpool;
 
 #define ETA(X,Y) ((struct stinger_etype_array *)(_ETA + ((Y)*stinger_etype_array_size((X)->max_neblocks))))
 
@@ -176,12 +188,12 @@ struct curs
 };
 
 
-static inline const struct stinger_eb *
+/*static inline const struct stinger_eb *
 stinger_next_eb (const struct stinger *G,
-                 const struct stinger_eb *eb_);
+                 const struct stinger_eb *eb_);*/
 
 int stinger_eb_high (const struct stinger_eb * eb_);
-static inline int64_t stinger_eb_type (const struct stinger_eb * eb_);
+/*static inline int64_t stinger_eb_type (const struct stinger_eb * eb_);*/
 
 int stinger_eb_is_blank (const struct stinger_eb * eb_, int k_);
 int64_t stinger_eb_adjvtx (const struct stinger_eb *, int);
@@ -208,7 +220,7 @@ void push_ebs (struct stinger *G, size_t neb,
 void stinger_fragmentation (struct stinger *S, uint64_t NV, struct stinger_fragmentation_t *frag);
 
 void
-new_blk_ebs (eb_index_t *out, const struct stinger * G,
+new_blk_ebs (eb_index_t *out, struct stinger * G,
              const int64_t nvtx, const size_t * blkoff,
              const int64_t etype);
 

--- a/lib/stinger_core/inc/stinger_names.h.in
+++ b/lib/stinger_core/inc/stinger_names.h.in
@@ -61,22 +61,22 @@ int
 stinger_names_create_type(stinger_names_t * sn, const char * name, int64_t * out);
 
 int64_t
-stinger_names_lookup_type(stinger_names_t * sn, const char * name);
+stinger_names_lookup_type(const stinger_names_t * sn, const char * name);
 
 char *
-stinger_names_lookup_name(stinger_names_t * sn, int64_t type);
+stinger_names_lookup_name(const stinger_names_t * sn, int64_t type);
 
 int64_t
-stinger_names_count(stinger_names_t * sn);
+stinger_names_count(const stinger_names_t * sn);
 
 int64_t
-stinger_names_remove_type(stinger_names_t * sn, int64_t type);
+stinger_names_remove_type(const stinger_names_t * sn, int64_t type);
 
 int64_t
 stinger_names_remove_name(stinger_names_t * sn, const char * name);
 
 void
-stinger_names_save(stinger_names_t * sn, FILE * fp);
+stinger_names_save(const stinger_names_t * sn, FILE * fp);
 
 void
 stinger_names_load(stinger_names_t * sn, FILE * fp);

--- a/lib/stinger_core/inc/stinger_physmap.h
+++ b/lib/stinger_core/inc/stinger_physmap.h
@@ -33,22 +33,22 @@ int
 stinger_physmap_mapping_create(stinger_physmap_t * p, stinger_vertices_t * v, const char * byte_string, int64_t length, int64_t * vtx_out);
 
 vindex_t
-stinger_physmap_vtx_lookup(stinger_physmap_t * p, stinger_vertices_t * v, const char * byte_string, int64_t length);
+stinger_physmap_vtx_lookup(const stinger_physmap_t * p, const stinger_vertices_t * v, const char * byte_string, int64_t length);
 
 int64_t
-stinger_physmap_vtx_remove_id(stinger_physmap_t *p, stinger_vertices_t * v, vindex_t vertexID);
+stinger_physmap_vtx_remove_id(const stinger_physmap_t *p, const stinger_vertices_t * v, vindex_t vertexID);
 
 int64_t
 stinger_physmap_vtx_remove_name(stinger_physmap_t *p, stinger_vertices_t * v, const char * byte_string, int64_t length);
 
 int
-stinger_physmap_id_get(stinger_physmap_t * p, stinger_vertices_t * v, vindex_t vertexID, char ** outbuffer, int64_t * outbufferlength);
+stinger_physmap_id_get(const stinger_physmap_t * p, const stinger_vertices_t * v, vindex_t vertexID, char ** outbuffer, uint64_t * outbufferlength);
 
 int
-stinger_physmap_id_direct(stinger_physmap_t * p, stinger_vertices_t * v, vindex_t vertexID, char ** out_ptr, int64_t * out_len);
+stinger_physmap_id_direct(const stinger_physmap_t * p, const stinger_vertices_t * v, vindex_t vertexID, char ** out_ptr, uint64_t * out_len);
 
 int64_t
-stinger_physmap_nv(stinger_physmap_t * p);
+stinger_physmap_nv(const stinger_physmap_t * p);
 
 void
 stinger_physmap_save(stinger_physmap_t * p, FILE * fp);

--- a/lib/stinger_core/inc/stinger_traversal.h
+++ b/lib/stinger_core/inc/stinger_traversal.h
@@ -128,11 +128,14 @@ extern "C" {
     while(current_eb__ != ebpool_priv) {                                                                  \
       int64_t source__ = current_eb__->vertexID;                                                          \
       int64_t type__ = current_eb__->etype;                                                               \
+      (void) source__;                                                                                    \
+      (void) type__;                                                                                      \
       EB_FILTER_ {                                                                                        \
         PARALLEL_                                                                                         \
-        for(uint64_t i__ = 0; i__ < stinger_eb_high(current_eb__); i__++) {                               \
+        for(int64_t i__ = 0; i__ < stinger_eb_high(current_eb__); i__++) {                               \
           if(!stinger_eb_is_blank(current_eb__, i__)) {                                                   \
             struct stinger_edge * current_edge__ = current_eb__->edges + i__;                             \
+            (void) current_edge__;                                                                        \
             EDGE_FILTER_ {
 
 #define STINGER_GENERIC_FORALL_EDGES_OF_VTX_END()         \
@@ -227,11 +230,13 @@ extern "C" {
     SELECT_TYPE_ { /* This sets t__ */                                                        \
       struct stinger_eb * ebpool_priv = ebpool->ebpool;                                       \
       PARALLEL_                                                                               \
-      for(uint64_t p__ = 0; p__ < ETA((STINGER_),(t__))->high; p__++) {                       \
+      for(int64_t p__ = 0; p__ < ETA((STINGER_),(t__))->high; p__++) {                       \
         struct stinger_eb *  current_eb__ = ebpool_priv+ ETA((STINGER_),(t__))->blocks[p__];  \
         int64_t source__ = current_eb__->vertexID;                                            \
         int64_t type__ = current_eb__->etype;                                                 \
-        for(uint64_t i__ = 0; i__ < stinger_eb_high(current_eb__); i__++) {                   \
+        (void) source__;                                                                      \
+        (void) type__;                                                                        \
+        for(int64_t i__ = 0; i__ < stinger_eb_high(current_eb__); i__++) {                   \
           if(!stinger_eb_is_blank(current_eb__, i__)) {                                       \
             struct stinger_edge * current_edge__ = current_eb__->edges + i__;                 \
             if (STINGER_IS_OUT_EDGE) {
@@ -252,7 +257,7 @@ extern "C" {
 
 // For all edges
 #define STINGER_FORALL_EDGES_OF_ALL_TYPES_BEGIN(STINGER_) \
-  STINGER_GENERIC_FORALL_EDGES_BEGIN(STINGER_,for (uint64_t t__ = 0; t__ < stinger_max_num_etypes(STINGER_); t__++),)
+  STINGER_GENERIC_FORALL_EDGES_BEGIN(STINGER_,for (int64_t t__ = 0; t__ < stinger_max_num_etypes(STINGER_); t__++),)
 #define STINGER_FORALL_EDGES_OF_ALL_TYPES_END() \
   STINGER_GENERIC_FORALL_EDGES_END()
 
@@ -264,7 +269,7 @@ extern "C" {
 
 // For all edges, in parallel
 #define STINGER_PARALLEL_FORALL_EDGES_OF_ALL_TYPES_BEGIN(STINGER_) \
-  STINGER_GENERIC_FORALL_EDGES_BEGIN(STINGER_,for (uint64_t t__ = 0; t__ < stinger_max_num_etypes(STINGER_); t__++),STINGER_FORALL_ENABLE_PARALLEL_)
+  STINGER_GENERIC_FORALL_EDGES_BEGIN(STINGER_,for (int64_t t__ = 0; t__ < stinger_max_num_etypes(STINGER_); t__++),STINGER_FORALL_ENABLE_PARALLEL_)
 #define STINGER_PARALLEL_FORALL_EDGES_OF_ALL_TYPES_END() \
   STINGER_GENERIC_FORALL_EDGES_END()
 
@@ -276,9 +281,10 @@ extern "C" {
     const struct stinger_eb * restrict ebp__ = ebpool->ebpool;                          \
     const int64_t source__ = (VTX_);                                                    \
     int64_t ebp_k__ = vertices->vertices[source__].edges;                               \
+    (void) S__;                                                                         \
     while(ebp_k__) {                                                                    \
       EB_FILTER_ {                                                                      \
-        for(uint64_t i__ = 0; i__ < ebp__[ebp_k__].high; i__++) {                       \
+        for(int64_t i__ = 0; i__ < ebp__[ebp_k__].high; i__++) {                       \
           if(!stinger_eb_is_blank(&ebp__[ebp_k__], i__)) {                              \
             const struct stinger_edge local_current_edge__ = ebp__[ebp_k__].edges[i__]; \
             if(local_current_edge__.neighbor >= 0) {                                    \
@@ -338,13 +344,14 @@ extern "C" {
     const struct stinger * restrict S__ = (STINGER_);                                       \
     const struct stinger_eb * restrict ebp__ = ebpool->ebpool;                              \
     const int64_t source__ = (VTX_);                                                        \
+    (void) S__;                                                                             \
     OMP("omp parallel") {                                                                   \
       OMP("omp single") {                                                                   \
         int64_t ebp_k__ = vertices->vertices[source__].edges;                               \
         while(ebp_k__) {                                                                    \
           EB_FILTER_ {                                                                      \
             OMP("omp task untied firstprivate(ebp_k__)")                                    \
-            for(uint64_t i__ = 0; i__ < ebp__[ebp_k__].high; i__++) {                       \
+            for(int64_t i__ = 0; i__ < ebp__[ebp_k__].high; i__++) {                       \
               if(!stinger_eb_is_blank(&ebp__[ebp_k__], i__)) {                              \
                 const struct stinger_edge local_current_edge__ = ebp__[ebp_k__].edges[i__]; \
                 if(local_current_edge__.neighbor >= 0) {                                    \
@@ -405,11 +412,14 @@ extern "C" {
         const struct stinger * restrict S__ = (STINGER_);               \
         const struct stinger_eb * restrict ebp__ = ebpool->ebpool;	\
         const int64_t etype__ = (TYPE_);                                \
-        for(uint64_t p__ = 0; p__ < ETA((STINGER_),(TYPE_))->high; p__++) {    \
+        (void) S__;                                                     \
+        (void) etype__;                                                 \
+        for(int64_t p__ = 0; p__ < ETA((STINGER_),(TYPE_))->high; p__++) {    \
           int64_t ebp_k__ = ETA((STINGER_),(TYPE_))->blocks[p__];              \
           const int64_t source__ = ebp__[ebp_k__].vertexID;             \
           const int64_t type__ = ebp__[ebp_k__].etype;                  \
-          for(uint64_t i__ = 0; i__ < ebp__[ebp_k__].high; i__++) {     \
+          (void) type__; \
+          for(int64_t i__ = 0; i__ < ebp__[ebp_k__].high; i__++) {     \
             if(!stinger_eb_is_blank(&ebp__[ebp_k__], i__)) {            \
               const struct stinger_edge local_current_edge__ = ebp__[ebp_k__].edges[i__]; \
               if(local_current_edge__.neighbor >= 0) {
@@ -428,12 +438,15 @@ extern "C" {
         const struct stinger * restrict S__ = (STINGER_);             \
         const int64_t etype__ = (TYPE_);                              \
         const struct stinger_eb * restrict ebp__ = ebpool->ebpool;	\
+        (void) S__; \
+        (void) etype__; \
         OMP("omp parallel for ")                                            \
-        for(uint64_t p__ = 0; p__ < ETA((STINGER_),(TYPE_))->high; p__++) { \
+        for(int64_t p__ = 0; p__ < ETA((STINGER_),(TYPE_))->high; p__++) { \
           int64_t ebp_k__ = ETA((STINGER_),(TYPE_))->blocks[p__];          \
           const int64_t source__ = ebp__[ebp_k__].vertexID;         \
           const int64_t type__ = ebp__[ebp_k__].etype;              \
-          for(uint64_t i__ = 0; i__ < ebp__[ebp_k__].high; i__++) { \
+          (void) type__; \
+          for(int64_t i__ = 0; i__ < ebp__[ebp_k__].high; i__++) { \
             if(!stinger_eb_is_blank(&ebp__[ebp_k__], i__)) {      \
               const struct stinger_edge local_current_edge__ = ebp__[ebp_k__].edges[i__]; \
               if(local_current_edge__.neighbor >= 0) {

--- a/lib/stinger_core/inc/stinger_vertex.h
+++ b/lib/stinger_core/inc/stinger_vertex.h
@@ -27,7 +27,7 @@ typedef int64_t adjacency_t;
   #define JSON_VWEIGHT(NAME,VAL) JSON_INT64(NAME,VAL)
   #define XML_ATTRIBUTE_VWEIGHT(NAME,VAL) XML_ATTRIBUTE_INT64(NAME,VAL)
   #define stinger_vweight_fetch_add_atomic(P,VAL) stinger_int64_fetch_add(P,VAL)
-  static inline vweight_t
+  inline vweight_t
   stinger_vweight_fetch_add(vweight_t * p, vweight_t val) {
     vweight_t out = *p;
     *p += val;
@@ -92,67 +92,67 @@ vtype_t
 stinger_vertex_type_get(const stinger_vertices_t * vertices, vindex_t v);
 
 vtype_t
-stinger_vertex_type_set(const stinger_vertices_t * vertices, vindex_t v, vtype_t type);
+stinger_vertex_type_set(stinger_vertices_t * vertices, vindex_t v, vtype_t type);
 
 vweight_t
 stinger_vertex_weight_get(const stinger_vertices_t * vertices, vindex_t v);
 
 vweight_t
-stinger_vertex_weight_set(const stinger_vertices_t * vertices, vindex_t v, vweight_t weight);
+stinger_vertex_weight_set(stinger_vertices_t * vertices, vindex_t v, vweight_t weight);
 
 vweight_t
-stinger_vertex_weight_increment(const stinger_vertices_t * vertices, vindex_t v, vweight_t weight);
+stinger_vertex_weight_increment(stinger_vertices_t * vertices, vindex_t v, vweight_t weight);
 
 vweight_t
-stinger_vertex_weight_increment_atomic(const stinger_vertices_t * vertices, vindex_t v, vweight_t weight);
+stinger_vertex_weight_increment_atomic(stinger_vertices_t * vertices, vindex_t v, vweight_t weight);
 
 vdegree_t
 stinger_vertex_degree_get(const stinger_vertices_t * vertices, vindex_t v);
 
 vdegree_t
-stinger_vertex_degree_set(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
+stinger_vertex_degree_set(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
 
 vdegree_t
-stinger_vertex_degree_increment(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
+stinger_vertex_degree_increment(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
 
 vdegree_t
-stinger_vertex_degree_increment_atomic(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
+stinger_vertex_degree_increment_atomic(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
 
 vdegree_t
 stinger_vertex_indegree_get(const stinger_vertices_t * vertices, vindex_t v);
 
 vdegree_t
-stinger_vertex_indegree_set(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
+stinger_vertex_indegree_set(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
 
 vdegree_t
-stinger_vertex_indegree_increment(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
+stinger_vertex_indegree_increment(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
 
 vdegree_t
-stinger_vertex_indegree_increment_atomic(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
+stinger_vertex_indegree_increment_atomic(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
 
 vdegree_t
 stinger_vertex_outdegree_get(const stinger_vertices_t * vertices, vindex_t v);
 
 vdegree_t
-stinger_vertex_outdegree_set(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
+stinger_vertex_outdegree_set(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
 
 vdegree_t
-stinger_vertex_outdegree_increment(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
+stinger_vertex_outdegree_increment(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
 
 vdegree_t
-stinger_vertex_outdegree_increment_atomic(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
+stinger_vertex_outdegree_increment_atomic(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree);
 
 adjacency_t
 stinger_vertex_edges_get(const stinger_vertices_t * vertices, vindex_t v);
 
 adjacency_t *
-stinger_vertex_edges_pointer_get(const stinger_vertices_t * vertices, vindex_t v);
+stinger_vertex_edges_pointer_get(stinger_vertices_t * vertices, vindex_t v);
 
 adjacency_t
-stinger_vertex_edges_get_and_lock(const stinger_vertices_t * vertices, vindex_t v);
+stinger_vertex_edges_get_and_lock(stinger_vertices_t * vertices, vindex_t v);
 
 adjacency_t
-stinger_vertex_edges_set(const stinger_vertices_t * vertices, vindex_t v, adjacency_t edges);
+stinger_vertex_edges_set(stinger_vertices_t * vertices, vindex_t v, adjacency_t edges);
 
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *
@@ -172,7 +172,10 @@ void
 stinger_vertices_free(stinger_vertices_t ** vertices);
 
 stinger_vertex_t *
-stinger_vertices_vertex_get(const stinger_vertices_t * vertices, vindex_t v);
+stinger_vertices_vertex_get(stinger_vertices_t * vertices, vindex_t v);
+
+const stinger_vertex_t *
+const_stinger_vertices_vertex_get(const stinger_vertices_t * vertices, vindex_t v);
 
 int64_t 
 stinger_vertices_max_vertices_get(const stinger_vertices_t * vertices);

--- a/lib/stinger_core/inc/x86_full_empty.h
+++ b/lib/stinger_core/inc/x86_full_empty.h
@@ -33,7 +33,7 @@ uint64_t
 writeef(volatile uint64_t * v, uint64_t new_val);
 
 uint64_t
-readff(volatile uint64_t * v);
+readff(volatile const uint64_t * v);
 
 uint64_t
 writeff(volatile uint64_t * v, uint64_t new_val);

--- a/lib/stinger_core/src/core_util.c
+++ b/lib/stinger_core/src/core_util.c
@@ -154,7 +154,6 @@ int64_t
 find_in_sorted (const int64_t tofind,
                 const int64_t N, const int64_t * restrict ary)
 {
-  int64_t out = -1;
   if (N <= 0)
     return -1;
 

--- a/lib/stinger_core/src/stinger.c
+++ b/lib/stinger_core/src/stinger.c
@@ -17,26 +17,50 @@
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *
  * ACCESS INTERNAL "CLASSES"
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+inline const stinger_vertices_t *
+const_stinger_vertices_get(const stinger_t * S) {
+  CONST_MAP_STING(S);
+  return vertices;
+}
+
+inline const stinger_physmap_t *
+const_stinger_physmap_get(const stinger_t * S) {
+  CONST_MAP_STING(S);
+  return physmap;
+}
+
+inline const stinger_names_t *
+const_stinger_vtype_names_get(const stinger_t * S) {
+  CONST_MAP_STING(S);
+  return vtype_names;
+}
+
+inline const stinger_names_t *
+const_stinger_etype_names_get(const stinger_t * S) {
+  CONST_MAP_STING(S);
+  return etype_names;
+}
+
 inline stinger_vertices_t *
-stinger_vertices_get(const stinger_t * S) {
+stinger_vertices_get(stinger_t * S) {
   MAP_STING(S);
   return vertices;
 }
 
 inline stinger_physmap_t *
-stinger_physmap_get(const stinger_t * S) {
+stinger_physmap_get(stinger_t * S) {
   MAP_STING(S);
   return physmap;
 }
 
 inline stinger_names_t *
-stinger_vtype_names_get(const stinger_t * S) {
+stinger_vtype_names_get(stinger_t * S) {
   MAP_STING(S);
   return vtype_names;
 }
 
 inline stinger_names_t *
-stinger_etype_names_get(const stinger_t * S) {
+stinger_etype_names_get(stinger_t * S) {
   MAP_STING(S);
   return etype_names;
 }
@@ -48,21 +72,21 @@ stinger_etype_names_get(const stinger_t * S) {
 
 inline vdegree_t
 stinger_degree_get(const stinger_t * S, vindex_t v) {
-  return stinger_vertex_degree_get(stinger_vertices_get(S), v);
+  return stinger_vertex_degree_get(const_stinger_vertices_get(S), v);
 }
 
 inline vdegree_t
-stinger_degree_set(const stinger_t * S, vindex_t v, vdegree_t d) {
+stinger_degree_set(stinger_t * S, vindex_t v, vdegree_t d) {
   return stinger_vertex_degree_set(stinger_vertices_get(S), v, d);
 }
 
 inline vdegree_t
-stinger_degree_increment(const stinger_t * S, vindex_t v, vdegree_t d) {
+stinger_degree_increment(stinger_t * S, vindex_t v, vdegree_t d) {
   return stinger_vertex_degree_increment(stinger_vertices_get(S), v, d);
 }
 
 inline vdegree_t
-stinger_degree_increment_atomic(const stinger_t * S, vindex_t v, vdegree_t d) {
+stinger_degree_increment_atomic(stinger_t * S, vindex_t v, vdegree_t d) {
   return stinger_vertex_degree_increment_atomic(stinger_vertices_get(S), v, d);
 }
 
@@ -70,21 +94,21 @@ stinger_degree_increment_atomic(const stinger_t * S, vindex_t v, vdegree_t d) {
 
 inline vdegree_t
 stinger_indegree_get(const stinger_t * S, vindex_t v) {
-  return stinger_vertex_indegree_get(stinger_vertices_get(S), v);
+  return stinger_vertex_indegree_get(const_stinger_vertices_get(S), v);
 }
 
 inline vdegree_t
-stinger_indegree_set(const stinger_t * S, vindex_t v, vdegree_t d) {
+stinger_indegree_set(stinger_t * S, vindex_t v, vdegree_t d) {
   return stinger_vertex_indegree_set(stinger_vertices_get(S), v, d);
 }
 
 inline vdegree_t
-stinger_indegree_increment(const stinger_t * S, vindex_t v, vdegree_t d) {
+stinger_indegree_increment(stinger_t * S, vindex_t v, vdegree_t d) {
   return stinger_vertex_indegree_increment(stinger_vertices_get(S), v, d);
 }
 
 inline vdegree_t
-stinger_indegree_increment_atomic(const stinger_t * S, vindex_t v, vdegree_t d) {
+stinger_indegree_increment_atomic(stinger_t * S, vindex_t v, vdegree_t d) {
   return stinger_vertex_indegree_increment_atomic(stinger_vertices_get(S), v, d);
 }
 
@@ -92,21 +116,22 @@ stinger_indegree_increment_atomic(const stinger_t * S, vindex_t v, vdegree_t d) 
 
 inline vdegree_t
 stinger_outdegree_get(const stinger_t * S, vindex_t v) {
-     return ((const stinger_vertices_t*)(S->storage))->vertices[v].outDegree;
+     CONST_MAP_STING(S);
+     return vertices->vertices[v].outDegree;
 }
 
 inline vdegree_t
-stinger_outdegree_set(const stinger_t * S, vindex_t v, vdegree_t d) {
+stinger_outdegree_set(stinger_t * S, vindex_t v, vdegree_t d) {
   return stinger_vertex_outdegree_set(stinger_vertices_get(S), v, d);
 }
 
 inline vdegree_t
-stinger_outdegree_increment(const stinger_t * S, vindex_t v, vdegree_t d) {
+stinger_outdegree_increment(stinger_t * S, vindex_t v, vdegree_t d) {
   return stinger_vertex_outdegree_increment(stinger_vertices_get(S), v, d);
 }
 
 inline vdegree_t
-stinger_outdegree_increment_atomic(const stinger_t * S, vindex_t v, vdegree_t d) {
+stinger_outdegree_increment_atomic(stinger_t * S, vindex_t v, vdegree_t d) {
   return stinger_vertex_outdegree_increment_atomic(stinger_vertices_get(S), v, d);
 }
 
@@ -114,12 +139,12 @@ stinger_outdegree_increment_atomic(const stinger_t * S, vindex_t v, vdegree_t d)
 
 vtype_t
 stinger_vtype_get(const stinger_t * S, vindex_t v) {
-  MAP_STING(S);
+  CONST_MAP_STING(S);
   return stinger_vertex_type_get(vertices, v);
 }
 
 vtype_t
-stinger_vtype_set(const stinger_t * S, vindex_t v, vtype_t type) {
+stinger_vtype_set(stinger_t * S, vindex_t v, vtype_t type) {
   MAP_STING(S);
   return stinger_vertex_type_set(vertices, v, type);
 }
@@ -128,24 +153,24 @@ stinger_vtype_set(const stinger_t * S, vindex_t v, vtype_t type) {
 
 vweight_t
 stinger_vweight_get(const stinger_t * S, vindex_t v) {
-  MAP_STING(S);
+  CONST_MAP_STING(S);
   return stinger_vertex_weight_get(vertices, v);
 }
 
 vweight_t
-stinger_vweight_set(const stinger_t * S, vindex_t v, vweight_t weight) {
+stinger_vweight_set(stinger_t * S, vindex_t v, vweight_t weight) {
   MAP_STING(S);
   return stinger_vertex_weight_set(vertices, v, weight);
 }
 
 vweight_t
-stinger_vweight_increment(const stinger_t * S, vindex_t v, vweight_t weight) {
+stinger_vweight_increment(stinger_t * S, vindex_t v, vweight_t weight) {
   MAP_STING(S);
   return stinger_vertex_weight_increment(vertices, v, weight);
 }
 
 vweight_t
-stinger_vweight_increment_atomic(const stinger_t * S, vindex_t v, vweight_t weight) {
+stinger_vweight_increment_atomic(stinger_t * S, vindex_t v, vweight_t weight) {
   MAP_STING(S);
   return stinger_vertex_weight_increment_atomic(vertices, v, weight);
 }
@@ -153,7 +178,7 @@ stinger_vweight_increment_atomic(const stinger_t * S, vindex_t v, vweight_t weig
 /* ADJACENCY */
 adjacency_t
 stinger_adjacency_get(const stinger_t * S, vindex_t v) {
-  MAP_STING(S);
+  CONST_MAP_STING(S);
   return stinger_vertex_edges_get(vertices, v);
 }
 
@@ -162,28 +187,28 @@ stinger_adjacency_get(const stinger_t * S, vindex_t v) {
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 int
-stinger_mapping_create(const stinger_t * S, const char * byte_string, uint64_t length, int64_t * vtx_out) {
+stinger_mapping_create(stinger_t * S, const char * byte_string, uint64_t length, int64_t * vtx_out) {
   return stinger_physmap_mapping_create(stinger_physmap_get(S), stinger_vertices_get(S), byte_string, length, vtx_out);
 }
 
 vindex_t
 stinger_mapping_lookup(const stinger_t * S, const char * byte_string, uint64_t length) {
-  return stinger_physmap_vtx_lookup(stinger_physmap_get(S), stinger_vertices_get(S), byte_string, length);
+  return stinger_physmap_vtx_lookup(const_stinger_physmap_get(S), const_stinger_vertices_get(S), byte_string, length);
 }
 
 int
 stinger_mapping_physid_get(const stinger_t * S, vindex_t vertexID, char ** outbuffer, uint64_t * outbufferlength) {
-  return stinger_physmap_id_get(stinger_physmap_get(S), stinger_vertices_get(S), vertexID, outbuffer, outbufferlength);
+  return stinger_physmap_id_get(const_stinger_physmap_get(S), const_stinger_vertices_get(S), vertexID, outbuffer, outbufferlength);
 }
 
 int
 stinger_mapping_physid_direct(const stinger_t * S, vindex_t vertexID, char ** out_ptr, uint64_t * out_len) {
-  return stinger_physmap_id_direct(stinger_physmap_get(S), stinger_vertices_get(S), vertexID, out_ptr, out_len);
+  return stinger_physmap_id_direct(const_stinger_physmap_get(S), const_stinger_vertices_get(S), vertexID, out_ptr, out_len);
 }
 
 vindex_t
 stinger_mapping_nv(const stinger_t * S) {
-  return stinger_physmap_nv(stinger_physmap_get(S));
+  return stinger_physmap_nv(const_stinger_physmap_get(S));
 }
 
 
@@ -192,23 +217,23 @@ stinger_mapping_nv(const stinger_t * S) {
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 int
-stinger_vtype_names_create_type(const stinger_t * S, const char * name, int64_t * out) {
+stinger_vtype_names_create_type(stinger_t * S, const char * name, int64_t * out) {
   return stinger_names_create_type(stinger_vtype_names_get(S), name, out);
 }
 
 int64_t
 stinger_vtype_names_lookup_type(const stinger_t * S, const char * name) {
-  return stinger_names_lookup_type(stinger_vtype_names_get(S), name);
+  return stinger_names_lookup_type(const_stinger_vtype_names_get(S), name);
 }
 
 char *
 stinger_vtype_names_lookup_name(const stinger_t * S, int64_t type) {
-  return stinger_names_lookup_name(stinger_vtype_names_get(S), type);
+  return stinger_names_lookup_name(const_stinger_vtype_names_get(S), type);
 }
 
 int64_t
 stinger_vtype_names_count(const stinger_t * S) {
-  return stinger_names_count(stinger_vtype_names_get(S));
+  return stinger_names_count(const_stinger_vtype_names_get(S));
 }
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *
@@ -222,17 +247,17 @@ stinger_etype_names_create_type(stinger_t * S, const char * name, int64_t * out)
 
 int64_t
 stinger_etype_names_lookup_type(const stinger_t * S, const char * name) {
-  return stinger_names_lookup_type(stinger_etype_names_get(S), name);
+  return stinger_names_lookup_type(const_stinger_etype_names_get(S), name);
 }
 
 char *
 stinger_etype_names_lookup_name(const stinger_t * S, int64_t type) {
-  return stinger_names_lookup_name(stinger_etype_names_get(S), type);
+  return stinger_names_lookup_name(const_stinger_etype_names_get(S), type);
 }
 
 int64_t
 stinger_etype_names_count(const stinger_t * S) {
-  return stinger_names_count(stinger_etype_names_get(S));
+  return stinger_names_count(const_stinger_etype_names_get(S));
 }
 
 
@@ -243,12 +268,12 @@ stinger_etype_names_count(const stinger_t * S) {
 
  
 static void
-get_from_ebpool (const struct stinger * S, eb_index_t *out, size_t k)
+get_from_ebpool (struct stinger * S, eb_index_t *out, size_t k)
 {
   MAP_STING(S);
   eb_index_t ebt0;
   {
-    ebt0 = stinger_int64_fetch_add (&(ebpool->ebpool_tail), k);
+    ebt0 = stinger_int64_fetch_add ((int64_t *) &(ebpool->ebpool_tail), k);
     if (ebt0 + k >= (S->max_neblocks)) {
       LOG_F("STINGER has run out of internal storage space.  Storing this graph will require a larger\n"
 	    "       initial STINGER allocation. Try reducing the number of vertices and/or edges per block in\n"
@@ -441,7 +466,7 @@ stinger_total_edges (const struct stinger * S)
 int64_t
 stinger_max_total_edges (const struct stinger * S)
 {
-  MAP_STING(S);
+  CONST_MAP_STING(S);
   return ebpool->ebpool_tail * STINGER_EDGEBLOCKSIZE;
 }
 
@@ -456,11 +481,11 @@ stinger_max_total_edges (const struct stinger * S)
 size_t
 stinger_graph_size (const struct stinger *S)
 {
-  MAP_STING(S);
+  CONST_MAP_STING(S);
   int64_t num_edgeblocks = ebpool->ebpool_tail;;
   int64_t size_edgeblock = sizeof(struct stinger_eb);
 
-  int64_t vertices_size = stinger_vertices_size_bytes(stinger_vertices_get(S));
+  int64_t vertices_size = stinger_vertices_size_bytes(const_stinger_vertices_get(S));
 
   int64_t result = (num_edgeblocks * size_edgeblock) + vertices_size;
 
@@ -508,18 +533,18 @@ struct stinger_size_t calculate_stinger_size(int64_t nv, int64_t nebs, int64_t n
 void
 stinger_print_eb(struct stinger_eb * eb) {
   printf(
-    "EB VTX:  %ld\n"
-    "  NEXT:    %ld\n"
-    "  TYPE:    %ld\n"
-    "  NUMEDGS: %ld\n"
-    "  HIGH:    %ld\n"
-    "  SMTS:    %ld\n"
-    "  LGTS:    %ld\n"
+    "EB VTX:  %" PRId64 "\n"
+    "  NEXT:    %" PRId64 "\n"
+    "  TYPE:    %" PRId64 "\n"
+    "  NUMEDGS: %" PRId64 "\n"
+    "  HIGH:    %" PRId64 "\n"
+    "  SMTS:    %" PRId64 "\n"
+    "  LGTS:    %" PRId64 "\n"
     "  EDGES:\n",
     eb->vertexID, eb->next, eb->etype, eb->numEdges, eb->high, eb->smallStamp, eb->largeStamp);
   uint64_t j = 0;
   for (; j < eb->high && j < STINGER_EDGEBLOCKSIZE; j++) {
-    printf("    TO: %s%ld WGT: %ld TSF: %ld TSR: %ld\n", 
+    printf("    TO: %s%" PRId64 " WGT: %" PRId64 " TSF: %" PRId64 " TSR: %" PRId64 "\n", 
       stinger_eb_adjvtx(eb,j) < 0 ? "x " : "  ", stinger_eb_adjvtx(eb,j) < 0 ? -1 : stinger_eb_adjvtx(eb,j), 
       stinger_eb_weight(eb,j), stinger_eb_first_ts(eb,j), stinger_eb_ts(eb,j));
   }
@@ -534,7 +559,7 @@ stinger_print_eb(struct stinger_eb * eb) {
       } else {
         direction = 'o';
       }
-      printf("   DIRECTION: %c TO: %ld WGT: %ld TSF: %ld TSR: %ld\n", 
+      printf("   DIRECTION: %c TO: %" PRId64 " WGT: %" PRId64 " TSF: %" PRId64 " TSR: %" PRId64 "\n", 
         direction, stinger_eb_adjvtx(eb,j), stinger_eb_weight(eb,j), stinger_eb_first_ts(eb,j), stinger_eb_ts(eb,j));
     }
   }
@@ -592,14 +617,14 @@ stinger_consistency_check (struct stinger *S, uint64_t NV)
       for (; j < curBlock->high && j < STINGER_EDGEBLOCKSIZE; j++) {
         if (!stinger_eb_is_blank (curBlock, j)) {
           if (stinger_eb_direction_in (curBlock, j)) {
-            stinger_int64_fetch_add (&outDegree[stinger_eb_adjvtx (curBlock, j)], 1);
+            stinger_int64_fetch_add ((int64_t *) &outDegree[stinger_eb_adjvtx (curBlock, j)], 1);
             curInDegree++;
           }
           if (stinger_eb_direction_out (curBlock, j)) {
-            stinger_int64_fetch_add (&inDegree[stinger_eb_adjvtx (curBlock, j)], 1);
+            stinger_int64_fetch_add ((int64_t *) &inDegree[stinger_eb_adjvtx (curBlock, j)], 1);
             curOutDegree++;
           }
-          stinger_int64_fetch_add (&degree[stinger_eb_adjvtx (curBlock, j)], 1);
+          stinger_int64_fetch_add ((int64_t *) &degree[stinger_eb_adjvtx (curBlock, j)], 1);
           curDegree++;
           numEdges++;
           if (stinger_eb_direction_out (curBlock, j)) {
@@ -632,15 +657,15 @@ stinger_consistency_check (struct stinger *S, uint64_t NV)
     }
 
     if (curOutDegree != stinger_outdegree_get(S, i)) {
-      LOG_E_A("%ld -- curOutDegree: %ld != stinger_outdegree: %ld",i,curOutDegree,stinger_outdegree_get(S,i));
+      LOG_E_A("%" PRIu64 " -- curOutDegree: %" PRIu64 " != stinger_outdegree: %" PRId64,i,curOutDegree,stinger_outdegree_get(S,i));
       returnCode |= 0x00000080;
     }
     if (curInDegree != stinger_indegree_get(S, i)) {
-      LOG_E_A("%ld -- curInDegree: %ld != stinger_indegree: %ld",i,curInDegree,stinger_indegree_get(S,i));
+      LOG_E_A("%" PRIu64 " -- curInDegree: %" PRIu64 " != stinger_indegree: %" PRId64,i,curInDegree,stinger_indegree_get(S,i));
       returnCode |= 0x00000100;
     }
     if (curDegree != stinger_degree_get(S, i)) {
-      LOG_E_A("%ld -- curDegree: %ld != stinger_degree: %ld",i,curDegree,stinger_degree_get(S,i));
+      LOG_E_A("%" PRIu64 " -- curDegree: %" PRIu64 " != stinger_degree: %" PRId64,i,curDegree,stinger_degree_get(S,i));
       returnCode |= 0x00000200;
     }
   }
@@ -649,7 +674,7 @@ stinger_consistency_check (struct stinger *S, uint64_t NV)
   
   for (uint64_t i = 0; i < NV; i++) {
     if (inDegree[i] != stinger_indegree_get(S,i)) {
-      LOG_E_A("%ld -- curInDegree: %ld != stinger_indegree: %ld",i,inDegree[i],stinger_indegree_get(S,i));
+      LOG_E_A("%" PRIu64 " -- curInDegree: %" PRIu64 " != stinger_indegree: %" PRId64,i,inDegree[i],stinger_indegree_get(S,i));
       returnCode |= 0x00001000;
     }
   }
@@ -658,7 +683,7 @@ stinger_consistency_check (struct stinger *S, uint64_t NV)
   
   for (uint64_t i = 0; i < NV; i++) {
     if (outDegree[i] != stinger_outdegree_get(S,i)){
-      LOG_E_A("%ld -- curOutDegree: %ld != stinger_outdegree: %ld",i,outDegree[i],stinger_outdegree_get(S,i));
+      LOG_E_A("%" PRIu64 " -- curOutDegree: %" PRIu64 " != stinger_outdegree: %" PRId64,i,outDegree[i],stinger_outdegree_get(S,i));
       returnCode |= 0x00000800;
     }
   }
@@ -667,7 +692,7 @@ stinger_consistency_check (struct stinger *S, uint64_t NV)
   
   for (uint64_t i = 0; i < NV; i++) {
     if (degree[i] != stinger_degree_get(S,i)){
-      LOG_E_A("%ld -- curDegree: %ld != stinger_degree: %ld",i,degree[i],stinger_degree_get(S,i));
+      LOG_E_A("%" PRIu64 " -- curDegree: %" PRIu64 " != stinger_degree: %" PRId64,i,degree[i],stinger_degree_get(S,i));
       returnCode |= 0x00002000;
     }
   }
@@ -793,7 +818,7 @@ struct stinger *stinger_new_full (struct stinger_config_t * config)
         exit(-1);
       }
       if(!resized) {
-        LOG_W_A("Resizing stinger to fit into memory (detected as %ld)", memory_size);
+        LOG_W_A("Resizing stinger to fit into memory (detected as %zu)", memory_size);
       }
       resized = 1;
 
@@ -877,7 +902,7 @@ struct stinger *stinger_new (void)
 struct stinger *
 stinger_free (struct stinger *S)
 {
-  size_t i;
+  /*size_t i;*/
   if (!S)
     return S;
 
@@ -907,7 +932,7 @@ stinger_free_all (struct stinger *S)
 eb_index_t new_eb (struct stinger * S, int64_t etype, int64_t from)
 {
   MAP_STING(S);
-  size_t k;
+  /*size_t k;*/
   eb_index_t out = 0;
   get_from_ebpool (S, &out, 1);
   struct stinger_eb * block = ebpool->ebpool + out;
@@ -944,7 +969,7 @@ new_ebs (struct stinger * S, eb_index_t *out, size_t neb, int64_t etype,
 
 
 void
-new_blk_ebs (eb_index_t *out, const struct stinger *restrict G,
+new_blk_ebs (eb_index_t *out, struct stinger *restrict G,
              const int64_t nvtx, const size_t * restrict blkoff,
              const int64_t etype)
 {
@@ -1016,7 +1041,7 @@ etype_begin (stinger_t * S, int64_t v, int etype)
   struct curs out;
   assert (vertices);
   out.eb = stinger_vertex_edges_get(vertices,v);
-  out.loc = stinger_vertex_edges_pointer_get(vertices,v);
+  out.loc = (eb_index_t *) stinger_vertex_edges_pointer_get(vertices,v);
   while (out.eb && ebpool->ebpool[out.eb].etype != etype) {
     out.loc = &(ebpool->ebpool[out.eb].next);
     out.eb = readff((uint64_t *)&(ebpool->ebpool[out.eb].next));
@@ -1034,7 +1059,7 @@ update_edge_data_and_direction (struct stinger * S, struct stinger_eb *eb,
 
   /* insertion */
   if (neighbor >= 0) {
-    int64_t weight = readfe (&(e->weight));
+    int64_t weight = readfe ((uint64_t *)&(e->weight));
     
     if (direction & STINGER_EDGE_DIRECTION_OUT) {
       if (operation & EDGE_WEIGHT_SET) {
@@ -1059,7 +1084,7 @@ update_edge_data_and_direction (struct stinger * S, struct stinger_eb *eb,
       if (index >= eb->high)
         eb->high = index + 1;
 
-      writexf(&e->timeFirst, ts);
+      writexf((uint64_t *)&e->timeFirst, ts);
     }
     else {
       if (direction & STINGER_EDGE_DIRECTION_OUT) {
@@ -1067,7 +1092,7 @@ update_edge_data_and_direction (struct stinger * S, struct stinger_eb *eb,
           int64_t n = e->neighbor;
           int64_t prev = stinger_int64_cas (&(e->neighbor), n, n | STINGER_EDGE_DIRECTION_OUT);
           if (prev == n && !(prev & STINGER_EDGE_DIRECTION_OUT)) {
-            writexf(&e->timeFirst, ts);
+            writexf((uint64_t *)&e->timeFirst, ts);
             stinger_outdegree_increment_atomic(S, eb->vertexID, 1);
           }
         }
@@ -1084,13 +1109,13 @@ update_edge_data_and_direction (struct stinger * S, struct stinger_eb *eb,
     
     if (direction & STINGER_EDGE_DIRECTION_OUT) { 
       /* check metadata and update - lock metadata for safety */
-      if (ts < readff(&eb->smallStamp) || ts > eb->largeStamp) {
-        int64_t smallStamp = readfe(&eb->smallStamp);
+      if (ts < readff((uint64_t *)&eb->smallStamp) || ts > eb->largeStamp) {
+        int64_t smallStamp = readfe((uint64_t *)&eb->smallStamp);
         if (ts < smallStamp)
           smallStamp = ts;
         if (ts > eb->largeStamp)
           eb->largeStamp = ts;
-        writeef(&eb->smallStamp, smallStamp);
+        writeef((uint64_t *)&eb->smallStamp, smallStamp);
       }
 
       e->timeRecent = ts;
@@ -1191,7 +1216,7 @@ stinger_update_directed_edge(struct stinger *G,
           }
 
           if (myNeighbor < 0 || k >= endk) {
-            int64_t timefirst = readfe ( &(tmp->edges[k].timeFirst) );
+            int64_t timefirst = readfe ( (uint64_t *)&(tmp->edges[k].timeFirst) );
             int64_t thisEdge = (tmp->edges[k].neighbor & (~STINGER_EDGE_DIRECTION_MASK));
             endk = tmp->high;
 
@@ -1199,17 +1224,17 @@ stinger_update_directed_edge(struct stinger *G,
               update_edge_data_and_direction (G, tmp, k, dest, weight, timestamp, direction, EDGE_WEIGHT_SET);;
               return 1;
             } else if (dest == thisEdge) {
-              int ret = 0;
+              /*int ret = 0;*/
               if (direction & tmp->edges[k].neighbor) {
-                ret = 0;
+                /*ret = 0;*/
               } else {
-                ret = 1;
+                /*ret = 1;*/
               }
               update_edge_data_and_direction (G, tmp, k, dest, weight, timestamp, direction, operation);
-              writexf ( &(tmp->edges[k].timeFirst), timefirst);
+              writexf ( (uint64_t *)&(tmp->edges[k].timeFirst), timefirst);
               return 0;
             } else {
-              writexf ( &(tmp->edges[k].timeFirst), timefirst);
+              writexf ( (uint64_t *)&(tmp->edges[k].timeFirst), timefirst);
             }
           }
         }
@@ -1432,9 +1457,9 @@ stinger_remove_edge (struct stinger *G,
   MAP_STING(G);
 
   struct curs curs;
-  struct stinger_eb *tmp_first, *tmp_second;
-  size_t k_first, k_second;
-  int64_t weight_first, weight_second;
+  struct stinger_eb *tmp_first = NULL, *tmp_second = NULL;
+  size_t k_first = 0, k_second = 0;
+  int64_t weight_first = 0, weight_second = 0;
   struct stinger_eb *ebpool_priv = ebpool->ebpool;
 
   int64_t lock_backedge_first = 0;
@@ -1455,7 +1480,7 @@ stinger_remove_edge (struct stinger *G,
 
       for (k_first = 0; k_first < endk; ++k_first) {
         if (to == stinger_eb_adjvtx(tmp_first,k_first) && stinger_eb_direction_out(tmp_first,k_first)) {
-          weight_first = readfe (&(tmp_first->edges[k_first].weight));
+          weight_first = readfe ((uint64_t *)&(tmp_first->edges[k_first].weight));
           if(to == stinger_eb_adjvtx(tmp_first,k_first) && stinger_eb_direction_out(tmp_first,k_first)) {
             if (lock_backedge_first) {
               goto removeEdges;
@@ -1492,7 +1517,7 @@ stinger_remove_edge (struct stinger *G,
 
       for (k_second = 0; k_second < endk; ++k_second) {
         if (from == stinger_eb_adjvtx(tmp_second,k_second) && stinger_eb_direction_in(tmp_second,k_second)) {
-          weight_second = readfe (&(tmp_second->edges[k_second].weight));
+          weight_second = readfe ((uint64_t *)&(tmp_second->edges[k_second].weight));
           if(from == stinger_eb_adjvtx(tmp_second,k_second) && stinger_eb_direction_in(tmp_second,k_second)) {
             if (lock_backedge_first) {
               goto removeForwardEdge;
@@ -2156,7 +2181,7 @@ stinger_set_edgeweight (struct stinger *G,
   STINGER_PARALLEL_FORALL_OUT_EDGES_OF_TYPE_OF_VTX_BEGIN(G,type,from) {
     if (STINGER_EDGE_DEST == to) {
 
-      int64_t cur_weight = readfe (&(current_edge__->weight));
+      (void) readfe ((uint64_t *)&(current_edge__->weight));
       writeef((uint64_t *)&(current_edge__->weight), (uint64_t)weight);
 
       rtn = 1;
@@ -2253,7 +2278,7 @@ stinger_edge_touch (struct stinger *G,
 
   STINGER_PARALLEL_FORALL_OUT_EDGES_OF_TYPE_OF_VTX_BEGIN(G,type,from) {
     if (STINGER_EDGE_DEST == to) {
-      int64_t cur_weight = readfe (&(current_edge__->weight));
+      int64_t cur_weight = readfe ((uint64_t *)&(current_edge__->weight));
       
       STINGER_EDGE_TIME_RECENT = timestamp;
       if (current_eb__->largeStamp < timestamp) {
@@ -2464,7 +2489,7 @@ stinger_remove_vertex (struct stinger *G, int64_t vtx_id)
   } STINGER_PARALLEL_FORALL_IN_EDGES_OF_VTX_END();
 
   // Remove from physmap
-  return stinger_physmap_vtx_remove_id(stinger_physmap_get(G),stinger_vertices_get(G),vtx_id);
+  return stinger_physmap_vtx_remove_id(const_stinger_physmap_get(G),const_stinger_vertices_get(G),vtx_id);
 }
 
 const int64_t endian_check = 0x1234ABCD;
@@ -2496,7 +2521,7 @@ stinger_save_to_file (struct stinger * S, uint64_t maxVtx, const char * stingerf
   /* TODO TODO TODO fix this function and the load function to work wihtout static sizes */
 
   MAP_STING(S);
-  uint64_t * restrict offsets = xcalloc((maxVtx+2) * (S->max_netypes), sizeof(uint64_t));
+  int64_t * restrict offsets = xcalloc((maxVtx+2) * (S->max_netypes), sizeof(int64_t));
 
   for(int64_t type = 0; type < (S->max_netypes); type++) {
     struct stinger_eb * local_ebpool = ebpool->ebpool;
@@ -2593,9 +2618,9 @@ stinger_save_to_file (struct stinger * S, uint64_t maxVtx, const char * stingerf
     written += fwrite(vdata, sizeof(int64_t), 2, fp);
   }
 
-  stinger_names_save(stinger_physmap_get(S), fp);
-  stinger_names_save(stinger_vtype_names_get(S), fp);
-  stinger_names_save(stinger_etype_names_get(S), fp);
+  stinger_names_save(const_stinger_physmap_get(S), fp);
+  stinger_names_save(const_stinger_vtype_names_get(S), fp);
+  stinger_names_save(const_stinger_etype_names_get(S), fp);
 
   fclose(fp);
 
@@ -2654,8 +2679,8 @@ stinger_open_from_file (const char * stingerfile, struct stinger * S, uint64_t *
     return -1;
   }
 
-  uint64_t * restrict offsets = xcalloc((*maxVtx+2) * etypes, sizeof(uint64_t));
-  uint64_t * restrict type_offsets = xmalloc((etypes+1) * sizeof(uint64_t));
+  int64_t * restrict offsets = xcalloc((*maxVtx+2) * etypes, sizeof(int64_t));
+  int64_t * restrict type_offsets = xmalloc((etypes+1) * sizeof(int64_t));
 
   result = fread(type_offsets, sizeof(int64_t), etypes+1, fp);
   result += fread(offsets, sizeof(int64_t), (*maxVtx+2) * etypes, fp);
@@ -2686,7 +2711,7 @@ stinger_open_from_file (const char * stingerfile, struct stinger * S, uint64_t *
     bs64_n(5 * type_offsets[etypes], ind);
   }
 
-  fprintf(stderr,"Loading %ld vertices and %ld etypes from file.\n",*maxVtx,etypes);
+  fprintf(stderr,"Loading %" PRIu64 " vertices and %" PRId64 " etypes from file.\n",*maxVtx,etypes);
 
   for(int64_t type = 0; type < etypes; type++) {
     stinger_set_initial_edges(S, *maxVtx, type, 
@@ -2699,10 +2724,9 @@ stinger_open_from_file (const char * stingerfile, struct stinger * S, uint64_t *
                               0);
   }
 
-  int ignore = 0;
   for(uint64_t v = 0; v < *maxVtx; v++) {
     int64_t vdata[2];
-    ignore = fread(vdata, sizeof(int64_t), 2, fp);
+    (void) fread(vdata, sizeof(int64_t), 2, fp);
     stinger_vtype_set(S, v, vdata[0]);
     stinger_vweight_set(S, v, vdata[1]);
   }

--- a/lib/stinger_core/src/stinger_deprecated.c
+++ b/lib/stinger_core/src/stinger_deprecated.c
@@ -101,8 +101,8 @@ stinger_remove_and_insert_edges (struct stinger *G,
   for (tmp = ebpool_priv + curs.eb; tmp != ebpool_priv; tmp = ebpool_priv + tmp->next) {
     if(tmp->etype == type) {
       size_t k, endk;
-      size_t found_k = STINGER_EDGEBLOCKSIZE;
-      size_t found_slot = STINGER_EDGEBLOCKSIZE;
+      /*size_t found_k = STINGER_EDGEBLOCKSIZE;*/
+      /*size_t found_slot = STINGER_EDGEBLOCKSIZE;*/
       prev_loc = &tmp->next;
       endk = tmp->high;
       ninsert_remaining = ninsert;
@@ -295,7 +295,7 @@ stinger_remove_and_insert_batch (struct stinger * G, int64_t type,
  *  @return Void
  */
 void
-stinger_gather_typed_successors_serial (const struct stinger *G, int64_t type,
+stinger_gather_typed_successors_serial (struct stinger *G, int64_t type,
                                         int64_t v, size_t * outlen,
                                         int64_t * out, size_t max_outlen)
 {

--- a/lib/stinger_core/src/stinger_names.c
+++ b/lib/stinger_core/src/stinger_names.c
@@ -27,11 +27,14 @@
     char * names = (char *)((X)->storage); \
     int64_t * to_name = (int64_t *)((X)->storage + (X)->to_name_start); \
     int64_t * from_name= (int64_t *)((X)->storage + (X)->from_name_start); \
-    int64_t * to_int = (int64_t *)((X)->storage + (X)->to_int_start);
+    int64_t * to_int = (int64_t *)((X)->storage + (X)->to_int_start); \
+    (void) to_name; \
+    (void) from_name; \
+    (void) to_int;
 
 
 static uint64_t
-xor_hash(uint8_t * byte_string, int64_t length) {
+xor_hash(const char * byte_string, int64_t length) {
   if(length < 0) length = 0;
 
   uint64_t out = 0;
@@ -232,7 +235,7 @@ stinger_names_create_type(stinger_names_t * sn, const char * name, int64_t * out
  * @return The type on success or -1 if the type does not exist.
  */
 int64_t
-stinger_names_lookup_type(stinger_names_t * sn, const char * name) {
+stinger_names_lookup_type(const stinger_names_t * sn, const char * name) {
   MAP_SN(sn)
       int64_t length = strlen(name); length = length > NAME_STR_MAX ? NAME_STR_MAX : length;
   int64_t index = xor_hash(name, length) % (sn->max_types * 2);
@@ -260,7 +263,7 @@ stinger_names_lookup_type(stinger_names_t * sn, const char * name) {
  * @return Returns string if the mapping exists or NULL.
  */
 char *
-stinger_names_lookup_name(stinger_names_t * sn, int64_t type) {
+stinger_names_lookup_name(const stinger_names_t * sn, int64_t type) {
   MAP_SN(sn)
       if(type < sn->max_types) {
         return names + to_name[type];
@@ -270,7 +273,7 @@ stinger_names_lookup_name(stinger_names_t * sn, int64_t type) {
 }
 
 int64_t
-stinger_names_count(stinger_names_t * sn) {
+stinger_names_count(const stinger_names_t * sn) {
   return sn->next_type;
 }
 
@@ -279,12 +282,12 @@ stinger_names_print(stinger_names_t * sn) {
   MAP_SN(sn)
 
       for(int64_t i = 0; i < sn->max_types*2; i++) {
-        printf("FROM_NAME %ld %s TO_INT %ld TO_NAME %ld\n", from_name[i], from_name[i] ? names + from_name[i] : "", to_int[i], to_int[i] ? to_name[to_int[i]] : 0);
+        printf("FROM_NAME %" PRId64 " %s TO_INT %" PRId64 " TO_NAME %" PRId64 "\n", from_name[i], from_name[i] ? names + from_name[i] : "", to_int[i], to_int[i] ? to_name[to_int[i]] : 0);
       }
 }
 
 int64_t
-stinger_names_remove_type(stinger_names_t * sn, int64_t type) {
+stinger_names_remove_type(const stinger_names_t * sn, int64_t type) {
   LOG_E("Deleting of stinger names is unsupported in base mode");
   return -1;
 }
@@ -309,7 +312,7 @@ stinger_names_remove_name(stinger_names_t * sn, const char * name) {
  * @param fp The file to write into.
  */
 void
-stinger_names_save(stinger_names_t * sn, FILE * fp) {
+stinger_names_save(const stinger_names_t * sn, FILE * fp) {
   MAP_SN(sn)
 
       int64_t max_len = NAME_STR_MAX;

--- a/lib/stinger_core/src/stinger_physmap.c
+++ b/lib/stinger_core/src/stinger_physmap.c
@@ -63,13 +63,13 @@ stinger_physmap_mapping_create(stinger_physmap_t * p, stinger_vertices_t * v, co
  * @retrun The vertex ID or -1 on failure.
  */
 vindex_t
-stinger_physmap_vtx_lookup(stinger_physmap_t * p, stinger_vertices_t * v, const char * byte_string, int64_t length)
+stinger_physmap_vtx_lookup(const stinger_physmap_t * p, const stinger_vertices_t * v, const char * byte_string, int64_t length)
 {
   return stinger_names_lookup_type(p, byte_string);
 }
 
 int64_t
-stinger_physmap_vtx_remove_id(stinger_physmap_t *p, stinger_vertices_t * v, vindex_t vertexID) {
+stinger_physmap_vtx_remove_id(const stinger_physmap_t *p, const stinger_vertices_t * v, vindex_t vertexID) {
   return stinger_names_remove_type(p, vertexID);
 }
 
@@ -91,11 +91,11 @@ stinger_physmap_vtx_remove_name(stinger_physmap_t *p, stinger_vertices_t * v, co
  * @retrun 0 on success, -1 on failure.
  */
 int
-stinger_physmap_id_get(stinger_physmap_t * p, stinger_vertices_t * v, vindex_t vertexID, char ** outbuffer, int64_t * outbufferlength)
+stinger_physmap_id_get(const stinger_physmap_t * p, const stinger_vertices_t * v, vindex_t vertexID, char ** outbuffer, uint64_t * outbufferlength)
 {
   char * name = stinger_names_lookup_name(p, vertexID);
   if(name) {
-    int len = strlen(name);
+    unsigned len = strlen(name);
 
     if(*outbuffer == NULL || *outbufferlength == 0){
       *outbuffer = xmalloc(len * sizeof(char));
@@ -118,7 +118,7 @@ stinger_physmap_id_get(stinger_physmap_t * p, stinger_vertices_t * v, vindex_t v
 }
 
 int
-stinger_physmap_id_direct(stinger_physmap_t * p, stinger_vertices_t * v, vindex_t vertexID, char ** out_ptr, int64_t * out_len)
+stinger_physmap_id_direct(const stinger_physmap_t * p, const stinger_vertices_t * v, vindex_t vertexID, char ** out_ptr, uint64_t * out_len)
 {
   char * name = stinger_names_lookup_name(p, vertexID);
   if(name) {
@@ -133,7 +133,7 @@ stinger_physmap_id_direct(stinger_physmap_t * p, stinger_vertices_t * v, vindex_
 }
 
 int64_t
-stinger_physmap_nv(stinger_physmap_t * p) {
+stinger_physmap_nv(const stinger_physmap_t * p) {
   return stinger_names_count(p);
 }
 

--- a/lib/stinger_core/src/stinger_shared.c
+++ b/lib/stinger_core/src/stinger_shared.c
@@ -150,7 +150,7 @@ stinger_shared_new_full (char ** out, struct stinger_config_t * config)
   if (*out == NULL)
   {
     *out = xmalloc(sizeof(char) * MAX_NAME_LEN);
-    sprintf(*out, "/%lx", (uint64_t)rand());
+    sprintf(*out, "/%" PRIu64, (uint64_t)rand());
   }                              
 
   int64_t nv      = config->nv      ? config->nv      : STINGER_DEFAULT_VERTICES;
@@ -175,7 +175,7 @@ stinger_shared_new_full (char ** out, struct stinger_config_t * config)
         exit(-1);
       }
       if(!resized) {
-        LOG_W_A("Resizing stinger to fit into memory (detected as %ld)", memory_size);
+        LOG_W_A("Resizing stinger to fit into memory (detected as %zu)", memory_size);
       }
       resized = 1;
 
@@ -281,6 +281,7 @@ stinger_shared_free (struct stinger *S, const char * name, size_t sz)
 
   int status = shmunmap(name, S, sz);
   status = shmunlink(name);
+  (void) status;
 
   return NULL;
 }

--- a/lib/stinger_core/src/stinger_vertex.c
+++ b/lib/stinger_core/src/stinger_vertex.c
@@ -1,6 +1,7 @@
 #include "stinger_vertex.h"
 #include "stinger_atomics.h"
 #include "x86_full_empty.h"
+#include "xmalloc.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -39,8 +40,17 @@ stinger_vertices_free(stinger_vertices_t ** vertices)
   *vertices = NULL;
 }
 
+inline const stinger_vertex_t *
+const_stinger_vertices_vertex_get(const stinger_vertices_t * vertices, vindex_t v)
+{
+  if (v >= vertices->max_vertices || v < 0) {
+    return NULL;
+  }
+  return &(vertices->vertices[v]);
+}
+
 inline stinger_vertex_t *
-stinger_vertices_vertex_get(const stinger_vertices_t * vertices, vindex_t v)
+stinger_vertices_vertex_get(stinger_vertices_t * vertices, vindex_t v)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return NULL;
@@ -67,6 +77,8 @@ stinger_vertices_size_bytes(const stinger_vertices_t * vertices)
 
 #define VTX(v) stinger_vertices_vertex_get(vertices, v)
  
+#define CONST_VTX(v) const_stinger_vertices_vertex_get(vertices, v)
+ 
 /* TYPE */
 
 inline vtype_t
@@ -75,11 +87,11 @@ stinger_vertex_type_get(const stinger_vertices_t * vertices, vindex_t v)
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
   }
-  return VTX(v)->type;
+  return CONST_VTX(v)->type;
 }
 
 inline vtype_t
-stinger_vertex_type_set(const stinger_vertices_t * vertices, vindex_t v, vtype_t type)
+stinger_vertex_type_set(stinger_vertices_t * vertices, vindex_t v, vtype_t type)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -95,11 +107,11 @@ stinger_vertex_weight_get(const stinger_vertices_t * vertices, vindex_t v)
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
   }
-  return VTX(v)->weight;
+  return CONST_VTX(v)->weight;
 }
 
 inline vweight_t
-stinger_vertex_weight_set(const stinger_vertices_t * vertices, vindex_t v, vweight_t weight)
+stinger_vertex_weight_set(stinger_vertices_t * vertices, vindex_t v, vweight_t weight)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -108,7 +120,7 @@ stinger_vertex_weight_set(const stinger_vertices_t * vertices, vindex_t v, vweig
 }
 
 inline vweight_t
-stinger_vertex_weight_increment(const stinger_vertices_t * vertices, vindex_t v, vweight_t weight)
+stinger_vertex_weight_increment(stinger_vertices_t * vertices, vindex_t v, vweight_t weight)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -117,7 +129,7 @@ stinger_vertex_weight_increment(const stinger_vertices_t * vertices, vindex_t v,
 }
 
 inline vweight_t
-stinger_vertex_weight_increment_atomic(const stinger_vertices_t * vertices, vindex_t v, vweight_t weight)
+stinger_vertex_weight_increment_atomic(stinger_vertices_t * vertices, vindex_t v, vweight_t weight)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -133,11 +145,11 @@ stinger_vertex_degree_get(const stinger_vertices_t * vertices, vindex_t v)
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
   }
-  return VTX(v)->degree;
+  return CONST_VTX(v)->degree;
 }
 
 inline vdegree_t
-stinger_vertex_degree_set(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
+stinger_vertex_degree_set(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -146,7 +158,7 @@ stinger_vertex_degree_set(const stinger_vertices_t * vertices, vindex_t v, vdegr
 }
 
 inline vdegree_t
-stinger_vertex_degree_increment(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
+stinger_vertex_degree_increment(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -155,7 +167,7 @@ stinger_vertex_degree_increment(const stinger_vertices_t * vertices, vindex_t v,
 }
 
 inline vdegree_t
-stinger_vertex_degree_increment_atomic(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
+stinger_vertex_degree_increment_atomic(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -171,11 +183,11 @@ stinger_vertex_indegree_get(const stinger_vertices_t * vertices, vindex_t v)
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
   }
-  return VTX(v)->inDegree;
+  return CONST_VTX(v)->inDegree;
 }
 
 inline vdegree_t
-stinger_vertex_indegree_set(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
+stinger_vertex_indegree_set(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -184,7 +196,7 @@ stinger_vertex_indegree_set(const stinger_vertices_t * vertices, vindex_t v, vde
 }
 
 inline vdegree_t
-stinger_vertex_indegree_increment(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
+stinger_vertex_indegree_increment(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -193,7 +205,7 @@ stinger_vertex_indegree_increment(const stinger_vertices_t * vertices, vindex_t 
 }
 
 inline vdegree_t
-stinger_vertex_indegree_increment_atomic(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
+stinger_vertex_indegree_increment_atomic(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -209,11 +221,11 @@ stinger_vertex_outdegree_get(const stinger_vertices_t * vertices, vindex_t v)
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
   }
-  return VTX(v)->outDegree;
+  return CONST_VTX(v)->outDegree;
 }
 
 inline vdegree_t
-stinger_vertex_outdegree_set(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
+stinger_vertex_outdegree_set(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -222,7 +234,7 @@ stinger_vertex_outdegree_set(const stinger_vertices_t * vertices, vindex_t v, vd
 }
 
 inline vdegree_t
-stinger_vertex_outdegree_increment(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
+stinger_vertex_outdegree_increment(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -231,7 +243,7 @@ stinger_vertex_outdegree_increment(const stinger_vertices_t * vertices, vindex_t
 }
 
 inline vdegree_t
-stinger_vertex_outdegree_increment_atomic(const stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
+stinger_vertex_outdegree_increment_atomic(stinger_vertices_t * vertices, vindex_t v, vdegree_t degree)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
@@ -247,11 +259,11 @@ stinger_vertex_edges_get(const stinger_vertices_t * vertices, vindex_t v)
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
   }
-  return readff(&(VTX(v)->edges));
+  return readff((const uint64_t *) &(CONST_VTX(v)->edges));
 }
 
 inline adjacency_t *
-stinger_vertex_edges_pointer_get(const stinger_vertices_t * vertices, vindex_t v)
+stinger_vertex_edges_pointer_get(stinger_vertices_t * vertices, vindex_t v)
 {  
   if (v >= vertices->max_vertices || v < 0) {
     return NULL;
@@ -260,16 +272,16 @@ stinger_vertex_edges_pointer_get(const stinger_vertices_t * vertices, vindex_t v
 }
 
 inline adjacency_t
-stinger_vertex_edges_get_and_lock(const stinger_vertices_t * vertices, vindex_t v)
+stinger_vertex_edges_get_and_lock(stinger_vertices_t * vertices, vindex_t v)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;
   }
-  return readfe(&(VTX(v)->edges));
+  return readfe((uint64_t *) &(VTX(v)->edges));
 }
 
 inline adjacency_t
-stinger_vertex_edges_set(const stinger_vertices_t * vertices, vindex_t v, adjacency_t edges)
+stinger_vertex_edges_set(stinger_vertices_t * vertices, vindex_t v, adjacency_t edges)
 {
   if (v >= vertices->max_vertices || v < 0) {
     return -1;

--- a/lib/stinger_core/src/x86_full_empty.c
+++ b/lib/stinger_core/src/x86_full_empty.c
@@ -21,7 +21,7 @@ readfe(volatile uint64_t * v) {
     while(val == MARKER) {
       val = *v;
     }
-    if(val == stinger_int64_cas(v, val, MARKER))
+    if(val == stinger_int64_cas((volatile int64_t *) v, val, MARKER))
       break;
   }
   return val;
@@ -36,14 +36,14 @@ writeef(volatile uint64_t * v, uint64_t new_val) {
     while(val != MARKER) {
       val = *v;
     }
-    if(MARKER == stinger_int64_cas(v, MARKER, new_val))
+    if(MARKER == stinger_int64_cas((volatile int64_t *) v, MARKER, new_val))
       break;
   }
   return val;
 }
 
 uint64_t
-readff(volatile uint64_t * v) {
+readff(volatile const uint64_t * v) {
   stinger_memory_barrier();
   uint64_t val = *v;
   while(val == MARKER) {
@@ -61,7 +61,7 @@ writeff(volatile uint64_t * v, uint64_t new_val) {
     while(val == MARKER) {
       val = *v;
     }
-    if(val == stinger_int64_cas(v, val, new_val))
+    if(val == stinger_int64_cas((volatile int64_t *) v, val, new_val))
       break;
   }
   return val;

--- a/lib/stinger_net/inc/send_rcv.h
+++ b/lib/stinger_net/inc/send_rcv.h
@@ -56,7 +56,7 @@ send_message(int socket, T & message) {
 
   delete [] buffer;
 
-  if (sent_bytes != message_length + sizeof(message_length)) {
+  if ((unsigned) sent_bytes != message_length + sizeof(message_length)) {
     return false;
   }
 

--- a/lib/stinger_net/inc/stinger_alg.h
+++ b/lib/stinger_net/inc/stinger_alg.h
@@ -78,13 +78,13 @@ typedef struct {
 } stinger_registered_alg;
 
 typedef struct {
-  char * name;		       /* required argument */
+  char const * name;		       /* required argument */
   const char * host;
   int port;
   int is_remote;
   int map_private;
   int64_t data_per_vertex;
-  char * data_description;
+  char const * data_description;
   char ** dependencies;
   int64_t num_dependencies;
 } stinger_register_alg_params;

--- a/lib/stinger_net/inc/stinger_alg_state.h
+++ b/lib/stinger_net/inc/stinger_alg_state.h
@@ -31,7 +31,7 @@ namespace gt {
     * Data should be handled through the server state.
     */
     struct StingerAlgState {
-      StingerAlgState() : state(ALG_STATE_READY_INIT), data_loc(""), level(0) { }
+      StingerAlgState() : data_loc(""), level(0), state(ALG_STATE_READY_INIT) { }
 
       std::string name;
       std::string data_loc;

--- a/lib/stinger_net/src/stinger_alg.cpp
+++ b/lib/stinger_net/src/stinger_alg.cpp
@@ -51,7 +51,7 @@ stinger_register_alg_impl(stinger_register_alg_params params)
   }
 
   LOG_D("About to set dependencies");
-  LOG_D_A("Count is [%ld]", params.num_dependencies);
+  LOG_D_A("Count is [%" PRId64 "]", params.num_dependencies);
   for(int64_t i = 0; i < params.num_dependencies; i++) {
     alg_to_server.add_req_dep_name(params.dependencies[i]);
   }
@@ -291,7 +291,7 @@ stinger_alg_begin_pre(stinger_registered_alg * alg)
     case NUMBERS_ONLY: {
       alg->batch_type = BATCH_NUMBERS_ONLY;
       OMP("omp parallel for")
-	for (size_t i = 0; i < server_to_alg->batch().insertions_size(); i++) {
+	for (int i = 0; i < server_to_alg->batch().insertions_size(); i++) {
 	  const EdgeInsertion & in = server_to_alg->batch().insertions(i);
 	  alg->insertions[i].type	  = in.type();
 	  alg->insertions[i].source	  = in.source();
@@ -303,7 +303,7 @@ stinger_alg_begin_pre(stinger_registered_alg * alg)
 	}
 
       OMP("omp parallel for")
-	for(size_t d = 0; d < server_to_alg->batch().deletions_size(); d++) {
+	for(int d = 0; d < server_to_alg->batch().deletions_size(); d++) {
 	  const EdgeDeletion & del	= server_to_alg->batch().deletions(d);
 	  alg->deletions[d].type	= del.type();
 	  alg->deletions[d].source	= del.source();
@@ -316,7 +316,7 @@ stinger_alg_begin_pre(stinger_registered_alg * alg)
     case STRINGS_ONLY: {
       alg->batch_type = BATCH_STRINGS_ONLY;
       OMP("omp parallel for")
-	for (size_t i = 0; i < server_to_alg->batch().insertions_size(); i++) {
+	for (int i = 0; i < server_to_alg->batch().insertions_size(); i++) {
 	  const EdgeInsertion & in = server_to_alg->batch().insertions(i);
 	  alg->insertions[i].type_str	      = in.type_str().c_str();
 	  alg->insertions[i].source_str	      = in.source_str().c_str();
@@ -328,7 +328,7 @@ stinger_alg_begin_pre(stinger_registered_alg * alg)
 	}
 
       OMP("omp parallel for")
-	for(size_t d = 0; d < server_to_alg->batch().deletions_size(); d++) {
+	for(int d = 0; d < server_to_alg->batch().deletions_size(); d++) {
 	  const EdgeDeletion & del = server_to_alg->batch().deletions(d);
 	  alg->deletions[d].type_str	      = del.type_str().c_str();
 	  alg->deletions[d].source_str	      = del.source_str().c_str();
@@ -341,7 +341,7 @@ stinger_alg_begin_pre(stinger_registered_alg * alg)
     case MIXED: {
       alg->batch_type = BATCH_MIXED;
       OMP("omp parallel for")
-	for (size_t i = 0; i < server_to_alg->batch().insertions_size(); i++) {
+	for (int i = 0; i < server_to_alg->batch().insertions_size(); i++) {
 	  const EdgeInsertion & in = server_to_alg->batch().insertions(i);
           if(in.has_type_str()) {
 	    alg->insertions[i].type_str		= in.type_str().c_str();
@@ -368,7 +368,7 @@ stinger_alg_begin_pre(stinger_registered_alg * alg)
 	}
 
       OMP("omp parallel for")
-	for(size_t d = 0; d < server_to_alg->batch().deletions_size(); d++) {
+	for(int d = 0; d < server_to_alg->batch().deletions_size(); d++) {
 	  const EdgeDeletion & del = server_to_alg->batch().deletions(d);
           if(del.has_type_str()) {
 	    alg->deletions[d].type_str		= del.type_str().c_str();
@@ -395,7 +395,7 @@ stinger_alg_begin_pre(stinger_registered_alg * alg)
   }
 
   OMP("omp parallel for")
-  for(size_t v = 0; v < server_to_alg->batch().vertex_updates_size(); v++) {
+  for(int v = 0; v < server_to_alg->batch().vertex_updates_size(); v++) {
     const VertexUpdate & up = server_to_alg->batch().vertex_updates(v);
     if(up.has_type_str()) {
       alg->vertex_updates[v].type_str		= up.type_str().c_str();
@@ -415,7 +415,7 @@ stinger_alg_begin_pre(stinger_registered_alg * alg)
   }
 
   OMP("omp parallel for")
-  for(size_t m = 0; m < server_to_alg->batch().metadata_size(); m++) {
+  for(int m = 0; m < server_to_alg->batch().metadata_size(); m++) {
     const std::string & meta = server_to_alg->batch().metadata(m);
     alg->metadata[m]         = (uint8_t *)meta.c_str();
     alg->metadata_lengths[m] = meta.size();
@@ -568,7 +568,7 @@ stinger_alg_begin_post(stinger_registered_alg * alg)
   switch(server_to_alg->batch().type()) {
     case NUMBERS_ONLY: {
       OMP("omp parallel for")
-	for (size_t i = 0; i < server_to_alg->batch().insertions_size(); i++) {
+	for (int i = 0; i < server_to_alg->batch().insertions_size(); i++) {
 	  const EdgeInsertion & in	      = server_to_alg->batch().insertions(i);
 	  alg->insertions[i].type_str	      = in.type_str().c_str();
 	  alg->insertions[i].source_str	      = in.source_str().c_str();
@@ -577,7 +577,7 @@ stinger_alg_begin_post(stinger_registered_alg * alg)
 	}
 
       OMP("omp parallel for")
-	for(size_t d = 0; d < server_to_alg->batch().deletions_size(); d++) {
+	for(int d = 0; d < server_to_alg->batch().deletions_size(); d++) {
 	  const EdgeDeletion & del	      = server_to_alg->batch().deletions(d);
 	  alg->deletions[d].type_str	      = del.type_str().c_str();
 	  alg->deletions[d].source_str	      = del.source_str().c_str();
@@ -588,7 +588,7 @@ stinger_alg_begin_post(stinger_registered_alg * alg)
 
     case STRINGS_ONLY: {
       OMP("omp parallel for")
-	for (size_t i = 0; i < server_to_alg->batch().insertions_size(); i++) {
+	for (int i = 0; i < server_to_alg->batch().insertions_size(); i++) {
 	  const EdgeInsertion & in	      = server_to_alg->batch().insertions(i);
 	  alg->insertions[i].type	      = in.type();
 	  alg->insertions[i].source	      = in.source();
@@ -600,7 +600,7 @@ stinger_alg_begin_post(stinger_registered_alg * alg)
 	}
 
       OMP("omp parallel for")
-	for(size_t d = 0; d < server_to_alg->batch().deletions_size(); d++) {
+	for(int d = 0; d < server_to_alg->batch().deletions_size(); d++) {
 	  const EdgeDeletion & del	      = server_to_alg->batch().deletions(d);
 	  alg->deletions[d].type	      = del.type();
 	  alg->deletions[d].source	      = del.source();
@@ -614,7 +614,7 @@ stinger_alg_begin_post(stinger_registered_alg * alg)
 
     case MIXED: {
       OMP("omp parallel for")
-	for (size_t i = 0; i < server_to_alg->batch().insertions_size(); i++) {
+	for (int i = 0; i < server_to_alg->batch().insertions_size(); i++) {
 	  const EdgeInsertion & in		= server_to_alg->batch().insertions(i);
 	  alg->insertions[i].type_str		= in.type_str().c_str();
 	  alg->insertions[i].type		= in.type();
@@ -628,7 +628,7 @@ stinger_alg_begin_post(stinger_registered_alg * alg)
 	}
 
       OMP("omp parallel for")
-	for(size_t d = 0; d < server_to_alg->batch().deletions_size(); d++) {
+	for(int d = 0; d < server_to_alg->batch().deletions_size(); d++) {
 	  const EdgeDeletion & del		= server_to_alg->batch().deletions(d);
 	  alg->deletions[d].type_str		= del.type_str().c_str();
 	  alg->deletions[d].type		= del.type();
@@ -644,7 +644,7 @@ stinger_alg_begin_post(stinger_registered_alg * alg)
   }
 
   OMP("omp parallel for")
-  for(size_t v = 0; v < server_to_alg->batch().vertex_updates_size(); v++) {
+  for(int v = 0; v < server_to_alg->batch().vertex_updates_size(); v++) {
     const VertexUpdate & up = server_to_alg->batch().vertex_updates(v);
     alg->vertex_updates[v].type_str		= up.type_str().c_str();
     alg->vertex_updates[v].type		= up.type();

--- a/lib/stinger_net/src/stinger_mon.cpp
+++ b/lib/stinger_net/src/stinger_mon.cpp
@@ -27,8 +27,8 @@ StingerMon::get_mon() {
   return *state;
 }
 
-StingerMon::StingerMon() : stinger(NULL), 
-  stinger_loc(""), stinger_sz(0), algs(NULL), alg_map(NULL),
+StingerMon::StingerMon() : algs(NULL), alg_map(NULL), stinger(NULL), 
+  stinger_loc(""), stinger_sz(0),
   waiting(0), wait_lock(0), max_time(-922337203685477580)
 {
   pthread_rwlock_init(&alg_lock, NULL);

--- a/lib/stinger_net/src/stinger_server_state.cpp
+++ b/lib/stinger_net/src/stinger_server_state.cpp
@@ -22,10 +22,16 @@ struct delete_functor
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *
  * PRIVATE METHODS
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-StingerServerState::StingerServerState() : port_streams(10102), port_algs(10103),
-				    convert_num_to_string(1), batch_count(0),
-				    alg_lock(1), stream_lock(1), batch_lock(1), dep_lock(1), mon_lock(1),
-				    write_alg_data(false), write_names(false), history_cap(0), out_dir("./"),
+StingerServerState::StingerServerState() : alg_lock(1), write_alg_data(false),
+				    history_cap(0),
+				    write_names(false), out_dir("./"),
+				    mon_lock(1),
+				    dep_lock(1),
+				    stream_lock(1), batch_lock(1),
+				    batch_count(0),
+				    port_streams(10102),
+				    port_algs(10103),
+				    convert_num_to_string(1),
 				    stinger_sz(0)
 {
   LOG_D("Initializing server state.");
@@ -543,7 +549,7 @@ StingerServerState::write_data()
   char name_buf[1024];
   if(write_names) {
     /* write current vertex names to file */
-    snprintf(name_buf, 1024, "%s/vertex_names.%ld.vtx", out_dir.c_str(), batch_count);
+    snprintf(name_buf, 1024, "%s/vertex_names.%" PRId64 ".vtx", out_dir.c_str(), batch_count);
 
     FILE * fp = fopen(name_buf, "w");
     stinger_names_save(stinger_physmap_get(stinger), fp);
@@ -551,7 +557,7 @@ StingerServerState::write_data()
     fclose(fp);
 
     /* remove previous vertex names */
-    snprintf(name_buf, 1024, "%s/vertex_names.%ld.vtx", out_dir.c_str(), batch_count-1);
+    snprintf(name_buf, 1024, "%s/vertex_names.%" PRId64 ".vtx", out_dir.c_str(), batch_count-1);
     if(access(name_buf, F_OK) != -1) {
       unlink(name_buf);
     }
@@ -565,7 +571,7 @@ StingerServerState::write_data()
       if(alg->state >= ALG_STATE_DONE) /* skip invalid, completed, etc. */
 	continue;
 
-      snprintf(name_buf, 1024, "%s/%s.%ld.rslt", out_dir.c_str(), alg->name.c_str(), batch_count);
+      snprintf(name_buf, 1024, "%s/%s.%" PRId64 ".rslt", out_dir.c_str(), alg->name.c_str(), batch_count);
 
       int64_t nv_max = stinger->max_nv;
       int64_t nv = stinger_mapping_nv(stinger);
@@ -621,7 +627,7 @@ StingerServerState::write_data()
 
       /* if there is a cap on history, erase (current - history) if it exists */
       if(history_cap) {
-	snprintf(name_buf, 1024, "%s/%s.%ld.rslt", out_dir.c_str(), alg->name.c_str(), batch_count - history_cap);
+	snprintf(name_buf, 1024, "%s/%s.%" PRId64 ".rslt", out_dir.c_str(), alg->name.c_str(), batch_count - history_cap);
 	if(access(name_buf, F_OK) != -1) {
 	  unlink(name_buf);
 	}

--- a/lib/stinger_utils/inc/json_support.h
+++ b/lib/stinger_utils/inc/json_support.h
@@ -16,7 +16,7 @@ extern "C" {
 #define JSON_OBJECT_START(X)	      JSON_PRINT_INDENT();  fprintf(json_out, "\"%s\" : {", #X); json_indent++;
 #define JSON_OBJECT_START_UNLABELED() JSON_PRINT_INDENT();  fprintf(json_out, "{"); json_indent++;
 #define JSON_DOUBLE(NAME,VAL)	      JSON_PRINT_INDENT();  fprintf(json_out, "%s\"%s\" : %lf", not_first++ ? ",\n" : "\n", #NAME, VAL);
-#define JSON_INT64(NAME,VAL)	      JSON_PRINT_INDENT();  fprintf(json_out, "%s\"%s\" : %ld", not_first++ ? ",\n" : "\n", #NAME, VAL);
+#define JSON_INT64(NAME,VAL)	      JSON_PRINT_INDENT();  fprintf(json_out, "%s\"%s\" : %" PRId64, not_first++ ? ",\n" : "\n", #NAME, VAL);
 #define JSON_STRING(NAME,VAL)	      JSON_PRINT_INDENT();  fprintf(json_out, "%s\"%s\" : \"%s\"", not_first++ ? ",\n" : "\n", #NAME, VAL);
 #define JSON_STRING_LEN(NAME,VAL,LEN) JSON_PRINT_INDENT();  fprintf(json_out, "%s\"%s\" : \"%.*s\"", not_first++ ? ",\n" : "\n", #NAME, LEN, VAL);
 #define JSON_SUBOBJECT(NAME)	      JSON_PRINT_INDENT();  fprintf(json_out, "%s\"%s\" : ", not_first++ ? ",\n" : "\n", #NAME);

--- a/lib/stinger_utils/inc/stinger_la.h
+++ b/lib/stinger_utils/inc/stinger_la.h
@@ -23,7 +23,7 @@ stinger_and(eweight_t a, eweight_t b);
 eweight_t
 stinger_or(eweight_t a, eweight_t b);
 
-int
+void
 stinger_matvec(stinger_t * S, eweight_t * vec_in, int64_t nv, eweight_t * vec_out, 
   eweight_t (*multiply)(eweight_t, eweight_t), eweight_t (*reduce)(eweight_t, eweight_t), 
   eweight_t empty);

--- a/lib/stinger_utils/inc/stinger_utils.h
+++ b/lib/stinger_utils/inc/stinger_utils.h
@@ -81,7 +81,7 @@ struct stinger *edge_list_to_stinger (int64_t nv, int64_t ne,
 		      int64_t * timeRecent, int64_t * timeFirst, 
 		      int64_t timestamp);
 
-void stinger_sort_edge_list (const struct stinger *S, const int64_t srcvtx, const int64_t type);
+void stinger_sort_edge_list (struct stinger *S, const int64_t srcvtx, const int64_t type);
 
 void bucket_sort_pairs (int64_t *array, size_t num);
 

--- a/lib/stinger_utils/inc/xml_support.h
+++ b/lib/stinger_utils/inc/xml_support.h
@@ -12,7 +12,7 @@ extern "C" {
 #define XML_PRINT_INDENT() for(uint64_t i = 0; i < xml_indent; i++) fprintf(xml_out, XML_TAB);
 #define XML_TAG_START(X)	      XML_PRINT_INDENT();  fprintf(xml_out, "<%s ", #X); xml_indent++;
 #define XML_ATTRIBUTE_DOUBLE(NAME,VAL)	      fprintf(xml_out, "%s=\"%lf\" ", #NAME, VAL);
-#define XML_ATTRIBUTE_INT64(NAME,VAL)	      fprintf(xml_out, "%s=\"%ld\" ", #NAME, VAL);
+#define XML_ATTRIBUTE_INT64(NAME,VAL)	      fprintf(xml_out, "%s=\"%" PRId64 "\" ", #NAME, VAL);
 #define XML_ATTRIBUTE_STRING(NAME,VAL)	      fprintf(xml_out, "\"%s\" : \"%s\",\n", #NAME, VAL);
 #define XML_TAG_END()			      fprintf(xml_out, ">\n");
 #define XML_TAG_END_AND_CLOSE()	      xml_indent--; fprintf(xml_out, "/>\n");

--- a/lib/stinger_utils/src/csv.c
+++ b/lib/stinger_utils/src/csv.c
@@ -31,7 +31,7 @@ readCSVLineDynamic(char delim, FILE * file, char ** buf, uint64_t * bufSize, cha
   locLengths[0] = 0;
   locFields[0] = locBuf;
 
-  int in_quote = 0;
+  /*int in_quote = 0;*/
   char cur = '\0';
   uint64_t length = 0;
   uint64_t start  = 0;
@@ -207,7 +207,7 @@ void
 printLine(char ** fields, uint64_t * lengths, uint64_t count) {
   uint64_t i = 0;
   for(; i < count; i++) {
-    printf("field[%ld] (%ld) = %s\n", i, lengths[i], fields[i]);
+    printf("field[%" PRIu64 "] (%" PRIu64 ") = %s\n", i, lengths[i], fields[i]);
   }
 }
 
@@ -220,9 +220,9 @@ csvIfIDExistsint8(FILE * fp, char delim, struct stinger * S, uint64_t nv, int8_t
 	stinger_mapping_physid_direct(S, v, &name, &len);
       char * type = stinger_vtype_names_lookup_name(S, stinger_vtype_get(S, v));
 	if(len && name) {
-	fprintf(fp, "%ld%c%.*s%c%s%c%ld%c%ld\n", v, delim, (int)len, name, delim, type ? type : "", delim, stinger_vtype(S,v), delim, (long)values[v]);
+	fprintf(fp, "%" PRIu64 "%c%.*s%c%s%c%" PRId64 "%c%ld\n", v, delim, (int)len, name, delim, type ? type : "", delim, stinger_vtype(S,v), delim, (long)values[v]);
 	} else {
-	fprintf(fp, "%ld%c%.*s%c%s%c%ld%c%ld\n", v, delim, 0, "", delim, type ? type : "", delim, stinger_vtype(S,v), delim, (long)values[v]);
+	fprintf(fp, "%" PRIu64 "%c%.*s%c%s%c%" PRId64 "%c%ld\n", v, delim, 0, "", delim, type ? type : "", delim, stinger_vtype(S,v), delim, (long)values[v]);
       }
     }
   }
@@ -237,9 +237,9 @@ csvIfIDExistsint64(FILE * fp, char delim, struct stinger * S, uint64_t nv, int64
 	stinger_mapping_physid_direct(S, v, &name, &len);
       char * type = stinger_vtype_names_lookup_name(S, stinger_vtype_get(S, v));
 	if(len && name) {
-	fprintf(fp, "%ld%c%.*s%c%s%c%ld%c%ld\n", v, delim, (int)len, name, delim, type ? type : "", delim, stinger_vtype(S,v), delim, values[v]);
+	fprintf(fp, "%" PRIu64 "%c%.*s%c%s%c%" PRId64 "%c%" PRId64 "\n", v, delim, (int)len, name, delim, type ? type : "", delim, stinger_vtype(S,v), delim, values[v]);
 	} else {
-	fprintf(fp, "%ld%c%.*s%c%s%c%ld%c%ld\n", v, delim, 0, "", delim, type ? type : "", delim, stinger_vtype(S,v), delim, values[v]);
+	fprintf(fp, "%" PRIu64 "%c%.*s%c%s%c%" PRId64 "%c%" PRId64 "\n", v, delim, 0, "", delim, type ? type : "", delim, stinger_vtype(S,v), delim, values[v]);
       }
     }
   }
@@ -254,9 +254,9 @@ csvIfIDExistsfloat(FILE * fp, char delim, struct stinger * S, uint64_t nv, float
 	stinger_mapping_physid_direct(S, v, &name, &len);
       char * type = stinger_vtype_names_lookup_name(S, stinger_vtype_get(S, v));
 	if(len && name) {
-	fprintf(fp, "%ld%c%.*s%c%s%c%ld%c%f\n", v, delim, (int)len, name, delim, type ? type : "", delim, stinger_vtype(S,v), delim, values[v]);
+	fprintf(fp, "%" PRIu64 "%c%.*s%c%s%c%" PRId64 "%c%f\n", v, delim, (int)len, name, delim, type ? type : "", delim, stinger_vtype(S,v), delim, values[v]);
 	} else {
-	fprintf(fp, "%ld%c%.*s%c%s%c%ld%c%f\n", v, delim, 0, "", delim, type ? type : "", delim, stinger_vtype(S,v), delim, values[v]);
+	fprintf(fp, "%" PRIu64 "%c%.*s%c%s%c%" PRId64 "%c%f\n", v, delim, 0, "", delim, type ? type : "", delim, stinger_vtype(S,v), delim, values[v]);
       }
     }
   }
@@ -271,9 +271,9 @@ csvIfIDExistsdouble(FILE * fp, char delim, struct stinger * S, uint64_t nv, doub
       char * type = stinger_vtype_names_lookup_name(S, stinger_vtype_get(S, v));
 	stinger_mapping_physid_direct(S, v, &name, &len);
 	if(len && name) {
-	fprintf(fp, "%ld%c%.*s%c%s%c%ld%c%lf\n", v, delim, (int)len, name, delim, type ? type : "", delim, stinger_vtype(S,v), delim, values[v]);
+	fprintf(fp, "%" PRIu64 "%c%.*s%c%s%c%" PRId64 "%c%lf\n", v, delim, (int)len, name, delim, type ? type : "", delim, stinger_vtype(S,v), delim, values[v]);
 	} else {
-	fprintf(fp, "%ld%c%.*s%c%s%c%ld%c%lf\n", v, delim, 0, "", delim, type ? type : "", delim, stinger_vtype(S,v), delim, values[v]);
+	fprintf(fp, "%" PRIu64 "%c%.*s%c%s%c%" PRId64 "%c%lf\n", v, delim, 0, "", delim, type ? type : "", delim, stinger_vtype(S,v), delim, values[v]);
       }
     }
   }

--- a/lib/stinger_utils/src/dimacs_support.c
+++ b/lib/stinger_utils/src/dimacs_support.c
@@ -127,7 +127,7 @@ load_dimacs_graph (struct stinger * S, const char * filename)
   ptr = remove_comments(ptr, 'p');
 
   /* the first real line must be a header that states the number of vertices and edges */
-  sscanf(ptr, "%s %*s %ld %ld\n", buffer, &NV, &NE);
+  sscanf(ptr, "%s %*s %" PRId64 " %" PRId64 "\n", buffer, &NV, &NE);
   //printf("NV: %ld, NE: %ld\n", NV, NE);
   ptr = strchr(ptr, '\n');
 
@@ -176,7 +176,7 @@ load_dimacs_graph (struct stinger * S, const char * filename)
    * is 0-indexed or 1-indexed because the DIMACS "specification"
    * is unspecified. */
 #define CHECK_EXTREME(a,OP,X) \
-  do { if (a OP X) { int64_t X2 = readfe (&X); if (a OP X2) X2 = a; writeef (&X, X2); } } while (0)
+  do { if (a OP X) { int64_t X2 = readfe ((uint64_t *) &X); if (a OP X2) X2 = a; writeef ((uint64_t *) &X, X2); } } while (0)
 
   int64_t minv = 2*NV, maxv = 0;
   

--- a/lib/stinger_utils/src/histogram.c
+++ b/lib/stinger_utils/src/histogram.c
@@ -28,11 +28,11 @@ histogram_label_counts(struct stinger * S, uint64_t * labels, int64_t count, cha
   free(sizes);
 
   char filename[1024];
-  sprintf(filename, "%s/%s.%ld.csv", path, name, iteration);
+  sprintf(filename, "%s/%s.%" PRId64 ".csv", path, name, iteration);
   FILE * fp = fopen(filename, "w");
   for(uint64_t v = 1; v < count+1; v++) {
     if(histogram[v]) {
-      fprintf(fp, "%ld, %ld\n", v, histogram[v]);
+      fprintf(fp, "%" PRIu64 ", %" PRIu64 "\n", v, histogram[v]);
     }
   }
   fclose(fp);
@@ -60,11 +60,11 @@ histogram_int64(struct stinger * S, int64_t * scores, int64_t count, char * path
     }
 
     char filename[1024];
-    sprintf(filename, "%s/%s.%ld.csv", path, name, iteration);
+    sprintf(filename, "%s/%s.%" PRId64 ".csv", path, name, iteration);
     FILE * fp = fopen(filename, "w");
     for(uint64_t v = 0; v < max+2; v++) {
       if(histogram[v]) {
-	fprintf(fp, "%ld, %ld\n", v, histogram[v]);
+	fprintf(fp, "%" PRIu64 ", %" PRIu64 "\n", v, histogram[v]);
       }
     }
     fclose(fp);
@@ -95,11 +95,11 @@ histogram_float(struct stinger * S, float * scores, int64_t count, char * path, 
     }
 
     char filename[1024];
-    sprintf(filename, "%s/%s.%ld.csv", path, name, iteration);
+    sprintf(filename, "%s/%s.%" PRId64 ".csv", path, name, iteration);
     FILE * fp = fopen(filename, "w");
     for(uint64_t v = 0; v < max+2; v++) {
       if(histogram[v]) {
-	fprintf(fp, "%ld, %ld\n", v, histogram[v]);
+	fprintf(fp, "%" PRIu64 ", %" PRIu64 "\n", v, histogram[v]);
       }
     }
     fclose(fp);
@@ -130,11 +130,11 @@ histogram_double(struct stinger * S, double * scores, int64_t count, char * path
     }
 
     char filename[1024];
-    sprintf(filename, "%s/%s.%ld.csv", path, name, iteration);
+    sprintf(filename, "%s/%s.%" PRId64 ".csv", path, name, iteration);
     FILE * fp = fopen(filename, "w");
     for(uint64_t v = 0; v < max+2; v++) {
       if(histogram[v]) {
-	fprintf(fp, "%ld, %ld\n", v, histogram[v]);
+	fprintf(fp, "%" PRIu64 ", %" PRIu64 "\n", v, histogram[v]);
       }
     }
     fclose(fp);

--- a/lib/stinger_utils/src/metisish_support.c
+++ b/lib/stinger_utils/src/metisish_support.c
@@ -90,7 +90,7 @@ load_metisish_graph (struct stinger * S, char * filename)
 {
   FILE * fp = fopen (filename, "r");
   char rowbuf[16385];
-  int64_t nv = 0, ne_ent = 0, ne = 0, fmt = 0, ncon = 0;
+  int64_t nv = 0, ne_ent = 0, fmt = 0, ncon = 0;
   int has_weight = 0;
 
   if (!fp)

--- a/lib/stinger_utils/src/stinger_la.c
+++ b/lib/stinger_utils/src/stinger_la.c
@@ -36,7 +36,7 @@ stinger_or(eweight_t a, eweight_t b)
   return a || b ? 1 : 0;
 }
 
-int
+void
 stinger_matvec(stinger_t * S, eweight_t * vec_in, int64_t nv, eweight_t * vec_out, 
   eweight_t (*multiply)(eweight_t, eweight_t), eweight_t (*reduce)(eweight_t, eweight_t), 
   eweight_t empty)
@@ -44,7 +44,7 @@ stinger_matvec(stinger_t * S, eweight_t * vec_in, int64_t nv, eweight_t * vec_ou
   OMP("omp parallel for")
   for(int64_t v = 0; v < nv; v++) {
     eweight_t out = empty;
-    eweight_t cur = empty;
+    /*eweight_t cur = empty;*/
     STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, v) {
       if(STINGER_EDGE_DEST < nv) {
         out = reduce(multiply(STINGER_EDGE_WEIGHT, vec_in[STINGER_EDGE_DEST]), out);

--- a/lib/stinger_utils/src/stinger_utils.c
+++ b/lib/stinger_utils/src/stinger_utils.c
@@ -305,9 +305,9 @@ edge_list_to_stinger (int64_t nv, int64_t ne,
 
   OMP("omp parallel for")
   for (int64_t i = 0; i < ne; i++) {
-    stinger_insert_edge (S, 0, sv[i], ev[i], w[i], (timeFirst)?timeFirst:timestamp);
+    stinger_insert_edge (S, 0, sv[i], ev[i], w[i], (timeFirst)?(*timeFirst):timestamp);
     if (timeRecent && timeRecent != timeFirst) {
-      stinger_edge_touch (S, sv[i], ev[i], 0, timeRecent);
+      stinger_edge_touch (S, sv[i], ev[i], 0, *timeRecent);
     }
   }
 
@@ -331,7 +331,7 @@ edge_list_to_stinger (int64_t nv, int64_t ne,
 * @param type Edge type of the adjacency list to sort
 */
 void
-stinger_sort_edge_list (const struct stinger *S, const int64_t srcvtx,
+stinger_sort_edge_list (struct stinger *S, const int64_t srcvtx,
                         const int64_t type)
 {
   MAP_STING(S);
@@ -717,7 +717,7 @@ int64_t
 find_in_sorted (const int64_t tofind,
                 const int64_t N, const int64_t * restrict ary)
 {
-  int64_t out = -1;
+  /*int64_t out = -1;*/
   if (N <= 0)
     return -1;
 

--- a/lib/stinger_utils/src/xml_support.c
+++ b/lib/stinger_utils/src/xml_support.c
@@ -3,11 +3,13 @@
 
 #define VTX(v) stinger_vertices_vertex_get(vertices, v)
 
+#define CONST_VTX(v) const_stinger_vertices_vertex_get(vertices, v)
+
 
 inline void
 stinger_vertex_to_xml(const stinger_vertices_t * vertices, vindex_t v, FILE * out, int64_t indent_level)
 {
-  const stinger_vertex_t * vout = VTX(v);
+  const stinger_vertex_t * vout = CONST_VTX(v);
 
   XML_INIT(out, indent_level);
   XML_TAG_START(vertex);

--- a/lib/vtx_set/inc/vtx_set.h
+++ b/lib/vtx_set/inc/vtx_set.h
@@ -22,10 +22,10 @@ vtx_set_new(int64_t size, char * name);
 vtx_set_t *
 vtx_set_free(vtx_set_t * ht);
 
-vtx_set_t * 
+void
 vtx_set_expand(vtx_set_t ** ht, int64_t new_size);
 
-vtx_set_t *
+void
 vtx_set_insert(vtx_set_t ** ht, int64_t k, int64_t v);
 
 int64_t *

--- a/lib/vtx_set/src/vtx_set.c
+++ b/lib/vtx_set/src/vtx_set.c
@@ -37,7 +37,7 @@ mfree(void * p, int64_t size) {
   munmap(p, size);
 }
 
-void *
+void
 mreplace(char * old_name, void * old_p, int64_t old_size, char * new_name) {
   char old_filename[1024] = VTX_SET_MMAP_PATH;
   strcat(old_filename, old_name);
@@ -92,7 +92,7 @@ vtx_set_free(vtx_set_t * ht) {
   return NULL;
 }
 
-vtx_set_t * 
+void
 vtx_set_expand(vtx_set_t ** ht, int64_t new_size) {
   int64_t pow = (*ht)->size;
 
@@ -125,7 +125,7 @@ vtx_set_expand(vtx_set_t ** ht, int64_t new_size) {
   *ht = tmp;
 }
 
-vtx_set_t *
+void
 vtx_set_insert(vtx_set_t ** ht, int64_t k, int64_t v) {
   if(((double)((*ht)->elements + (*ht)->removed)) > (0.7f) * ((double)(*ht)->size)) {
     vtx_set_expand(ht, (*ht)->size * 2);

--- a/src/clients/algorithms/betweenness/src/betweenness.c
+++ b/src/clients/algorithms/betweenness/src/betweenness.c
@@ -60,7 +60,7 @@ main(int argc, char *argv[])
                     "aggregated and potentially weighted with the result from\n"
                     "the last pass\n"
                     "\n"
-                    "  -s <num>  Set the number of samples (%ld by default)\n"
+                    "  -s <num>  Set the number of samples (%" PRId64 " by default)\n"
                     "  -w <num>  Set the weighintg (0.0 - 1.0) (%lf by default)\n"
                     "  -x        Disable weighting\n"
                     "  -n <str>  Set the algorithm name (%s by default)\n"

--- a/src/clients/algorithms/community_detection/src/community_detection.c
+++ b/src/clients/algorithms/community_detection/src/community_detection.c
@@ -45,7 +45,7 @@ main(int argc, char *argv[])
                                 "\n"
                                 "This approach returns the first level of Louvain's Community detection\n"
                                 "\n"
-                                "  -i <num>  Set the max number of iterations (%ld by default)\n"
+                                "  -i <num>  Set the max number of iterations (%" PRId64 " by default)\n"
                                 "  -n <str>  Set the algorithm name (%s by default)\n"
                                 "\n", max_iter,alg_name
                 );

--- a/src/clients/algorithms/diameter/src/diameter.cpp
+++ b/src/clients/algorithms/diameter/src/diameter.cpp
@@ -21,7 +21,7 @@ main(int argc, char *argv[]) {
     int64_t dist = 0; //this is a placeholder that stores the length of the diameter in the graph, do not change this value
     bool ignore_weights = false;
 
-    char * alg_name = "pseudo_diameter";
+    char const * alg_name = "pseudo_diameter";
     stinger_register_alg_params params;
     params.name= "pseudo_diameter";
     params.data_per_vertex=sizeof(int64_t);
@@ -36,7 +36,7 @@ main(int argc, char *argv[]) {
                     .data_description="l vertexPool",
                     .host="localhost",
             );*/
-    int weighting;
+    double weighting = 0.0;
     int opt = 0;
     while(-1 != (opt = getopt(argc, argv, "w:s:n:?h"))) {
         switch(opt) {
@@ -50,7 +50,7 @@ main(int argc, char *argv[]) {
             } break;
             case 's': {
                 source_vertex = atol(optarg);
-                if(source_vertex < 0 || source_vertex > alg->stinger->max_nv ) {
+                if(source_vertex < 0 || ((uint64_t) source_vertex) > alg->stinger->max_nv ) {
                     //we need to check to make sure that the source vertex is set to a real vertex
                     source_vertex = 0;
                 }
@@ -74,9 +74,9 @@ main(int argc, char *argv[]) {
                                 "and ends when the graph distance no longer increases. \n"
                                 "\n"
                                 "  -s <num>  Set source vertex (%d by default)\n"
-                                "  -n <str>  Set the algorithm name (%s by default)\n"
                                 "  -w <num>  Set the weighting (0.0 - 1.0) (%lf by default)\n"
-                                "\n", 0, weighting, alg_name, 0
+                                "  -n <str>  Set the algorithm name (%s by default)\n"
+                                "\n", 0, weighting, alg_name
                 );
                 return(opt);
             }

--- a/src/clients/algorithms/graph_partition/src/graph_partition.c
+++ b/src/clients/algorithms/graph_partition/src/graph_partition.c
@@ -15,8 +15,8 @@
 int
 main(int argc, char *argv[]) {
 
-    char name[1024];
-    char type_str[1024];
+    /*char name[1024];
+    char type_str[1024];*/
 
     stinger_registered_alg * alg =
     stinger_register_alg(
@@ -50,7 +50,7 @@ main(int argc, char *argv[]) {
                                 "partitions using a linear greedy heuristic and limits the partition sizes based on the \n"
                                 "capacity constraint\n"
                                 "\n"
-                                "  -p        Set number of partitions (default: %ld)\n"
+                                "  -p        Set number of partitions (default: %d)\n"
                                 "  -c        Set partition capacity (default: %0.1e)\n"
                                 "\n",num_partitons,partition_capacity);
                 return(opt);

--- a/src/clients/algorithms/hits_centrality/src/hits.c
+++ b/src/clients/algorithms/hits_centrality/src/hits.c
@@ -50,7 +50,7 @@ main(int argc, char *argv[])
                                 "An authority value is computed as the sum of the scaled hub values, and conversely a \n"
                                 "hub value is the sum of the scaled authority values of the pages it points to.\n"
                                 "\n"
-                                "  -k <num>  Set the maximum number of iterations (%ld by default)\n"
+                                "  -k <num>  Set the maximum number of iterations (%" PRId64 " by default)\n"
                                 "  -n <str>  Set the algorithm name (%s by default)\n"
                                 "\n", num_iter,  alg_name
                 );
@@ -65,7 +65,7 @@ main(int argc, char *argv[])
     stinger_registered_alg * alg =
     stinger_register_alg(
             .name=alg_name,
-    .data_per_vertex=sizeof(double) + sizeof(double),
+    .data_per_vertex=sizeof(double_t) + sizeof(double_t),
     .data_description="ll hubs_scores authority_scores",
     .host="localhost",
     );
@@ -75,8 +75,8 @@ main(int argc, char *argv[])
         return -1;
     }
 
-    double * hubs_scores = (double *)alg->alg_data;
-    double * authority_scores = (int64_t *)(hubs_scores + alg->stinger->max_nv);
+    double_t * hubs_scores = (double_t *)alg->alg_data;
+    double_t * authority_scores = (double_t *)(hubs_scores + alg->stinger->max_nv);
 
     /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *
     * Initial static computation

--- a/src/clients/algorithms/pagerank/src/pagerank.c
+++ b/src/clients/algorithms/pagerank/src/pagerank.c
@@ -18,7 +18,7 @@ main(int argc, char *argv[])
   char type_str[1024];
 
   int type_specified = 0;
-  int directed = 0;
+  /*int directed = 0;*/
 
   double epsilon = EPSILON_DEFAULT;
   double dampingfactor = DAMPINGFACTOR_DEFAULT;
@@ -33,7 +33,7 @@ main(int argc, char *argv[])
         type_specified = 1;
       } break;
       case 'd': {
-        directed = 1;
+        /*directed = 1;*/
       } break;
       case 'e': {
         epsilon = atof(optarg);
@@ -53,10 +53,10 @@ main(int argc, char *argv[])
                         "==================================\n"
                         "\n"
                         "  -t <str>  Specify an edge type to run page rank over\n"
-                        "  -d        Use a PageRank that is safe on directed graphs\n"
+                        "  -d        Use a PageRank that is safe on directed graphs (no effect)\n"
                         "  -e        Set PageRank Epsilon (default: %0.1e)\n"
                         "  -f        Set PageRank Damping Factor (default: %lf)\n"
-                        "  -i        Set PageRank Max Iterations (default: %ld)\n"
+                        "  -i        Set PageRank Max Iterations (default: %d)\n"
                         "\n",EPSILON_DEFAULT,DAMPINGFACTOR_DEFAULT,MAXITER_DEFAULT);
         return(opt);
       }

--- a/src/clients/algorithms/pagerank_updating/src/pagerank_updating.c
+++ b/src/clients/algorithms/pagerank_updating/src/pagerank_updating.c
@@ -26,7 +26,7 @@ void clear_vlist (int64_t * restrict nvlist,
 static inline void normalize_pr (const int64_t nv, double * restrict pr_val);
 static int64_t find_max_pr (const int64_t nv, const double * restrict pr_val);
 
-static int nonunit_weights = 1;
+/*static int nonunit_weights = 1;*/
 
 struct spvect {
   int64_t nv;
@@ -44,8 +44,8 @@ static inline struct spvect alloc_spvect (int64_t nvmax);
 int
 main(int argc, char *argv[])
 {
-  double init_time, gather_time, compute_b_time;
-  double cwise_err;
+  double compute_b_time = 0.0;
+  /*double cwise_err;*/
 
   int iter = 0;
   int64_t nv;
@@ -229,7 +229,7 @@ main(int argc, char *argv[])
             }
         }
       }
-      gather_time = toc ();
+      (void) toc ();
 
       OMP("omp parallel for" OMP_SIMD)
         for (int64_t k = 0; k < x.nv; ++k)
@@ -368,21 +368,21 @@ main(int argc, char *argv[])
     }
 
     fprintf (stderr, "%ld: %12s %g\n", (long)iter, "b_time", compute_b_time);
-    int64_t loc_baseline;
+    /*int64_t loc_baseline;*/
     for (int alg = 0; alg <= DPR_HELD; ++alg) {
       double err = 0.0, mxerr = 0.0;
-      int64_t where = -1, nerr = 0;
-      const int64_t loc = find_max_pr (nv, pr_val[alg]);
-      if (alg == 0) loc_baseline = loc;
+      int64_t /*where = -1, */nerr = 0;
+      (void) find_max_pr (nv, pr_val[alg]);
+      /*if (alg == 0) loc_baseline = loc;*/
       if (alg > 0)
         //OMP("omp parallel for reduction(+: err)")
         for (int64_t i = 0; i < nv; ++i) {
           const double ei = fabs (pr_val[alg][i] - pr_val[BASELINE][i]);
-          if (ei > mxerr) { where = i; mxerr = ei; }
+          if (ei > mxerr) { /*where = i; */mxerr = ei; }
           err += ei;
           if (ei > 0.0) ++nerr;
         }
-      fprintf (stderr, "%ld: %12s %d\t%d %10g %8ld %10e %8ld %8ld\n",
+      fprintf (stderr, "%ld: %12s %d\t%d %10g %8" PRId64 " %10e %8ld %8ld\n",
                (long)iter, pr_name[alg], alg,
                niter[alg], pr_time[alg], pr_vol[alg], err, (long)nerr, (long)pr_nupd[alg]);
     }

--- a/src/clients/algorithms/pagerank_updating/src/spmspv.c
+++ b/src/clients/algorithms/pagerank_updating/src/spmspv.c
@@ -6,6 +6,7 @@
 
 #include "stinger_core/stinger_atomics.h"
 #include "stinger_core/stinger.h"
+#include "stinger_core/xmalloc.h"
 
 #include "compat.h"
 
@@ -29,7 +30,7 @@ static inline void setup_y (const int64_t nv, const double beta, double * y)
 #define ALPHAXI_VAL(alpha, xi) (alpha == 0.0? 0.0 : (alpha == 1.0? xi : (alpha == -1.0? -xi : (alpha * xi))))
 #define DEGSCALE(axi, degi) (degi == 0? 0.0 : axi / degi);
 
-void stinger_dspmTv (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_dspmTv (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   setup_y (nv, beta, y);
 
@@ -43,7 +44,7 @@ void stinger_dspmTv (const int64_t nv, const double alpha, const struct stinger 
   }
 }
 
-void stinger_unit_dspmTv (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_unit_dspmTv (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   setup_y (nv, beta, y);
 
@@ -56,7 +57,7 @@ void stinger_unit_dspmTv (const int64_t nv, const double alpha, const struct sti
   }
 }
 
-void stinger_dspmTv_degscaled (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_dspmTv_degscaled (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   setup_y (nv, beta, y);
 
@@ -72,7 +73,7 @@ void stinger_dspmTv_degscaled (const int64_t nv, const double alpha, const struc
   }
 }
 
-void stinger_unit_dspmTv_degscaled (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_unit_dspmTv_degscaled (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   setup_y (nv, beta, y);
 
@@ -87,7 +88,7 @@ void stinger_unit_dspmTv_degscaled (const int64_t nv, const double alpha, const 
   }
 }
 
-static void setup_workspace (const int64_t nv, int64_t ** loc_ws, double ** val_ws)
+static void setup_workspace (const int64_t nv, int64_t * restrict * loc_ws, double * restrict * val_ws)
 {
   if (!*loc_ws) {
     *loc_ws = xmalloc (nv * sizeof (**loc_ws));
@@ -120,14 +121,14 @@ static void setup_sparse_y (const double beta,
   } else if (1.0 != beta) {
     for (int64_t k = 0; k < y_deg; ++k) {
       const int64_t i = y_idx[k];
-      const double yi = y_val[k];
+      /*const double yi = y_val[k];*/
       loc_ws[i] = k;
       y_val[k] = beta * y_val[k];
     }
   }
 }
 
-void stinger_dspmTspv (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_dspmTspv (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t y_deg = * y_deg_ptr;
   int64_t * restrict loc_ws = loc_ws_in;
@@ -158,7 +159,7 @@ void stinger_dspmTspv (const int64_t nv, const double alpha, const struct stinge
   *y_deg_ptr = y_deg;
 }
 
-void stinger_unit_dspmTspv (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_unit_dspmTspv (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t y_deg = * y_deg_ptr;
   int64_t * restrict loc_ws = loc_ws_in;
@@ -188,7 +189,7 @@ void stinger_unit_dspmTspv (const int64_t nv, const double alpha, const struct s
   *y_deg_ptr = y_deg;
 }
 
-void stinger_dspmTspv_degscaled (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_dspmTspv_degscaled (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t y_deg = * y_deg_ptr;
   int64_t * restrict loc_ws = loc_ws_in;
@@ -221,7 +222,7 @@ void stinger_dspmTspv_degscaled (const int64_t nv, const double alpha, const str
   *y_deg_ptr = y_deg;
 }
 
-void stinger_unit_dspmTspv_degscaled (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_unit_dspmTspv_degscaled (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t y_deg = * y_deg_ptr;
   int64_t * restrict loc_ws = loc_ws_in;

--- a/src/clients/algorithms/pagerank_updating/src/spmspv_ompcas.c
+++ b/src/clients/algorithms/pagerank_updating/src/spmspv_ompcas.c
@@ -94,7 +94,7 @@ static inline void setup_y (const int64_t nv, const double beta, double * y)
 #define DEGSCALE(axi, degi) (degi == 0? 0.0 : axi / degi);
 
 static inline void
-dspmTv_accum (const struct stinger * S, const int64_t i, const double alphaxi, double * y)
+dspmTv_accum (struct stinger * S, const int64_t i, const double alphaxi, double * y)
 {
   STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, i) {
     const int64_t j = STINGER_EDGE_DEST;
@@ -104,7 +104,7 @@ dspmTv_accum (const struct stinger * S, const int64_t i, const double alphaxi, d
 }
 
 static inline void
-dspmTv_unit_accum (const struct stinger * S, const int64_t i, const double alphaxi, double * y)
+dspmTv_unit_accum (struct stinger * S, const int64_t i, const double alphaxi, double * y)
 {
   STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, i) {
     const int64_t j = STINGER_EDGE_DEST;
@@ -112,7 +112,7 @@ dspmTv_unit_accum (const struct stinger * S, const int64_t i, const double alpha
   } STINGER_FORALL_OUT_EDGES_OF_VTX_END();
 }
 
-void stinger_dspmTv_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_dspmTv_ompcas (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel if(!omp_in_parallel())") {
     setup_y (nv, beta, y);
@@ -126,7 +126,7 @@ void stinger_dspmTv_ompcas (const int64_t nv, const double alpha, const struct s
   }
 }
 
-void stinger_unit_dspmTv_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_unit_dspmTv_ompcas (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel if(!omp_in_parallel())") {
     setup_y (nv, beta, y);
@@ -140,7 +140,7 @@ void stinger_unit_dspmTv_ompcas (const int64_t nv, const double alpha, const str
   }
 }
 
-void stinger_dspmTv_degscaled_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_dspmTv_degscaled_ompcas (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel if(!omp_in_parallel())") {
     setup_y (nv, beta, y);
@@ -157,7 +157,7 @@ void stinger_dspmTv_degscaled_ompcas (const int64_t nv, const double alpha, cons
   }
 }
 
-void stinger_unit_dspmTv_degscaled_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_unit_dspmTv_degscaled_ompcas (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel if(!omp_in_parallel())") {
     setup_y (nv, beta, y);
@@ -224,7 +224,7 @@ static void setup_sparse_y (const double beta,
     OMP("omp for")
       for (int64_t k = 0; k < y_deg; ++k) {
         const int64_t i = y_idx[k];
-        const double yi = y_val[k];
+        /*const double yi = y_val[k];*/
         loc_ws[i] = k;
         val_ws[i] = beta * y_val[k];
       }
@@ -238,7 +238,7 @@ dspmTspv_y_idx_accum (const struct stinger * S,
                       int64_t * loc_ws)
 {
 #if !defined(NDEBUG)
-  const int64_t nv = stinger_max_active_vertex (S) + 1;
+  /*const int64_t nv =*/(void) (stinger_max_active_vertex (S) + 1);
 #endif
   if (loc_ws[j] == -1) {
     int64_t where;
@@ -257,7 +257,7 @@ dspmTspv_y_idx_accum (const struct stinger * S,
 }
 
 static inline void
-dspmTspv_accum (const struct stinger * S, const int64_t i, const double alphaxi,
+dspmTspv_accum (struct stinger * S, const int64_t i, const double alphaxi,
                 int64_t * y_deg, int64_t * y_idx, double * y,
                 int64_t * loc_ws)
 {
@@ -270,7 +270,7 @@ dspmTspv_accum (const struct stinger * S, const int64_t i, const double alphaxi,
 }
 
 static inline void
-dspmTspv_unit_accum (const struct stinger * S, const int64_t i, const double alphaxi,
+dspmTspv_unit_accum (struct stinger * S, const int64_t i, const double alphaxi,
                      int64_t * y_deg, int64_t * y_idx, double * y,
                      int64_t * loc_ws)
 {
@@ -293,7 +293,7 @@ pack_vals (const int64_t y_deg, const int64_t * restrict y_idx,
     }
 }
 
-void stinger_dspmTspv_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_dspmTspv_ompcas (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;
@@ -320,7 +320,7 @@ void stinger_dspmTspv_ompcas (const int64_t nv, const double alpha, const struct
   }
 }
 
-void stinger_unit_dspmTspv_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_unit_dspmTspv_ompcas (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;
@@ -347,7 +347,7 @@ void stinger_unit_dspmTspv_ompcas (const int64_t nv, const double alpha, const s
   }
 }
 
-void stinger_dspmTspv_degscaled_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_dspmTspv_degscaled_ompcas (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;
@@ -377,7 +377,7 @@ void stinger_dspmTspv_degscaled_ompcas (const int64_t nv, const double alpha, co
   }
 }
 
-void stinger_unit_dspmTspv_degscaled_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_unit_dspmTspv_degscaled_ompcas (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;

--- a/src/clients/algorithms/pagerank_updating/src/spmspv_ompcas_batch.c
+++ b/src/clients/algorithms/pagerank_updating/src/spmspv_ompcas_batch.c
@@ -94,7 +94,7 @@ static inline void setup_y (const int64_t nv, const double beta, double * y)
 #define DEGSCALE(axi, degi) (degi == 0? 0.0 : axi / degi);
 
 static inline void
-dspmTv_accum (const struct stinger * S, const int64_t i, const double alphaxi, double * y)
+dspmTv_accum (struct stinger * S, const int64_t i, const double alphaxi, double * y)
 {
   STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, i) {
     const int64_t j = STINGER_EDGE_DEST;
@@ -104,7 +104,7 @@ dspmTv_accum (const struct stinger * S, const int64_t i, const double alphaxi, d
 }
 
 static inline void
-dspmTv_unit_accum (const struct stinger * S, const int64_t i, const double alphaxi, double * y)
+dspmTv_unit_accum (struct stinger * S, const int64_t i, const double alphaxi, double * y)
 {
   STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, i) {
     const int64_t j = STINGER_EDGE_DEST;
@@ -112,7 +112,7 @@ dspmTv_unit_accum (const struct stinger * S, const int64_t i, const double alpha
   } STINGER_FORALL_OUT_EDGES_OF_VTX_END();
 }
 
-void stinger_dspmTv_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_dspmTv_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel") {
     setup_y (nv, beta, y);
@@ -126,7 +126,7 @@ void stinger_dspmTv_ompcas_batch (const int64_t nv, const double alpha, const st
   }
 }
 
-void stinger_unit_dspmTv_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_unit_dspmTv_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel") {
     setup_y (nv, beta, y);
@@ -140,7 +140,7 @@ void stinger_unit_dspmTv_ompcas_batch (const int64_t nv, const double alpha, con
   }
 }
 
-void stinger_dspmTv_degscaled_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_dspmTv_degscaled_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel") {
     setup_y (nv, beta, y);
@@ -157,7 +157,7 @@ void stinger_dspmTv_degscaled_ompcas_batch (const int64_t nv, const double alpha
   }
 }
 
-void stinger_unit_dspmTv_degscaled_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_unit_dspmTv_degscaled_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   //OMP("omp parallel")
   {
@@ -175,7 +175,7 @@ void stinger_unit_dspmTv_degscaled_ompcas_batch (const int64_t nv, const double 
   }
 }
 
-static void setup_workspace (const int64_t nv, int64_t ** loc_ws, double ** val_ws)
+static void setup_workspace (const int64_t nv, int64_t * restrict * loc_ws, double * restrict * val_ws)
 {
   if (!*loc_ws) {
     abort ();
@@ -227,7 +227,7 @@ static void setup_sparse_y (const double beta,
     OMP("omp for" OMP_SIMD)
       for (int64_t k = 0; k < y_deg; ++k) {
         const int64_t i = y_idx[k];
-        const double yi = y_val[k];
+        /*const double yi = y_val[k];*/
         loc_ws[i] = k;
         val_ws[i] = beta * y_val[k];
       }
@@ -286,7 +286,7 @@ enqueue (struct batch * b, const int64_t j, int64_t * y_deg, int64_t * y_idx, in
 }
 
 static inline void
-dspmTspv_accum (const struct stinger * S, const int64_t i, const double alphaxi,
+dspmTspv_accum (struct stinger * S, const int64_t i, const double alphaxi,
                 int64_t * y_deg, int64_t * y_idx, double * y,
                 int64_t * loc_ws, struct batch *b)
 {
@@ -299,7 +299,7 @@ dspmTspv_accum (const struct stinger * S, const int64_t i, const double alphaxi,
 }
 
 static inline void
-dspmTspv_unit_accum (const struct stinger * S, const int64_t i, const double alphaxi,
+dspmTspv_unit_accum (struct stinger * S, const int64_t i, const double alphaxi,
                      int64_t * y_deg, int64_t * y_idx, double * y,
                      int64_t * loc_ws, struct batch *b)
 {
@@ -322,7 +322,7 @@ pack_vals (const int64_t y_deg, const int64_t * restrict y_idx,
     }
 }
 
-void stinger_dspmTspv_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
+void stinger_dspmTspv_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;
@@ -354,7 +354,7 @@ void stinger_dspmTspv_ompcas_batch (const int64_t nv, const double alpha, const 
   }
 }
 
-void stinger_unit_dspmTspv_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
+void stinger_unit_dspmTspv_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;
@@ -384,7 +384,7 @@ void stinger_unit_dspmTspv_ompcas_batch (const int64_t nv, const double alpha, c
   }
 }
 
-void stinger_dspmTspv_degscaled_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
+void stinger_dspmTspv_degscaled_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;
@@ -417,7 +417,7 @@ void stinger_dspmTspv_degscaled_ompcas_batch (const int64_t nv, const double alp
   }
 }
 
-void stinger_unit_dspmTspv_degscaled_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in, int64_t * total_vol)
+void stinger_unit_dspmTspv_degscaled_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in, int64_t * total_vol)
 {
   static int64_t vol;
   int64_t * restrict loc_ws = loc_ws_in;
@@ -461,7 +461,7 @@ void stinger_unit_dspmTspv_degscaled_ompcas_batch (const int64_t nv, const doubl
 }
 
 
-void stinger_unit_dspmTspv_degscaled_held_ompcas_batch (const double holdthresh, const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in, int64_t * total_vol)
+void stinger_unit_dspmTspv_degscaled_held_ompcas_batch (const double holdthresh, const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in, int64_t * total_vol)
 {
   static int64_t vol;
   int64_t * restrict loc_ws = loc_ws_in;

--- a/src/clients/algorithms/simple_communities/src/community-update.c
+++ b/src/clients/algorithms/simple_communities/src/community-update.c
@@ -13,6 +13,8 @@
 #include "stinger_net/stinger_alg.h"
 #include "stinger_utils/timer.h"
 
+#include "compat/luc.h"
+
 #include "compat.h"
 #include "sorts.h"
 #include "graph-el.h"
@@ -24,7 +26,7 @@
 static void update_el (struct el * el,
                        int64_t * cmap,
                        int64_t * csize,
-                       const struct stinger * S,
+                       struct stinger * S,
                        const int64_t nvlist, const int64_t * restrict vlist,
                        int64_t * mark,
                        int64_t ** ws, size_t *wslen);
@@ -138,7 +140,7 @@ cstate_check (struct community_state *cstate)
   const int64_t nv = cstate->cg.nv;
   const int64_t ne = cstate->cg.ne;
   int64_t * restrict csize = cstate->csize;
-  const int64_t * restrict cmap = cstate->cmap;
+  /*const int64_t * restrict cmap = cstate->cmap;*/
   const struct el el = cstate->cg;
   CDECL(el);
   OMP("omp parallel") {
@@ -235,7 +237,7 @@ cstate_dump_cmap (struct community_state * cstate, long which, long num)
 }
 
 double
-cstate_update (struct community_state * cstate, const struct stinger * S)
+cstate_update (struct community_state * cstate, struct stinger * S)
 {
   tic ();
 
@@ -423,7 +425,7 @@ two options:
 
 static void
 extract_edges (const int64_t nvlist, const int64_t * restrict vlist, const int64_t * restrict cmap,
-               const struct stinger * restrict S,
+               struct stinger * restrict S,
                const int64_t * restrict mark,
                struct el * restrict g,
                const int64_t new_nv)
@@ -568,7 +570,7 @@ void
 update_el (struct el * el,
            int64_t * cmap,
            int64_t * csize,
-           const struct stinger * S,
+           struct stinger * S,
            const int64_t nvlist, const int64_t * restrict vlist,
            int64_t * mark,
            int64_t ** ws, size_t *wslen)
@@ -667,7 +669,7 @@ append_to_vlist (int64_t * restrict nvlist,
 }
 
 void cstate_preproc (struct community_state * restrict cstate,
-                     const struct stinger * S,
+                     struct stinger * S,
                      const int64_t nincr, const int64_t * restrict incr,
                      const int64_t nrem, const int64_t * restrict rem)
 {
@@ -759,7 +761,7 @@ void cstate_preproc (struct community_state * restrict cstate,
 }
 
 void cstate_preproc_acts (struct community_state * restrict cstate,
-                          const struct stinger * S,
+                          struct stinger * S,
                           const int64_t nact, const int64_t * restrict act)
 {
   const int64_t * restrict cmap = cstate->cmap;
@@ -892,7 +894,7 @@ double
 cstate_preproc_alg (struct community_state * restrict cstate,
                    const stinger_registered_alg * alg)
 {
-  const struct stinger * S = alg->stinger;
+  struct stinger * S = alg->stinger;
   const int64_t nincr = alg->num_insertions;
   const stinger_edge_update * restrict incr = alg->insertions;
   const int64_t nrem = alg->num_deletions;

--- a/src/clients/algorithms/simple_communities/src/community-update.h
+++ b/src/clients/algorithms/simple_communities/src/community-update.h
@@ -38,15 +38,15 @@ void init_empty_community_state (struct community_state * cstate, const int64_t 
 double init_and_compute_community_state (struct community_state * cstate, struct el * g);
 double init_and_read_community_state (struct community_state * cstate, int64_t graph_nv, const char *cg_name, const char *cmap_name);
 void cstate_dump_cmap (struct community_state * cstate, long which, long num);
-double cstate_update (struct community_state * cstate, const struct stinger * S);
+double cstate_update (struct community_state * cstate, struct stinger * S);
 
 void cstate_preproc (struct community_state * restrict,
-                     const struct stinger *,
+                     struct stinger *,
                      const int64_t, const int64_t * restrict,
                      const int64_t, const int64_t * restrict);
 
 void cstate_preproc_acts (struct community_state * restrict,
-                          const struct stinger *,
+                          struct stinger *,
                           const int64_t, const int64_t * restrict);
 
 #if !defined(INSQUEUE_SIZE)

--- a/src/clients/algorithms/simple_communities/src/community.c
+++ b/src/clients/algorithms/simple_communities/src/community.c
@@ -138,11 +138,11 @@ convert_el_match_to_relabel (const struct el g,
     OMP("omp barrier");
     OMP("omp for schedule(static)")
       for (int64_t k = 0; k < g.ne; ++k) {
-        if (count[k] < 0) fprintf (stderr, "%ld WTF?!?\n", k);
+        if (count[k] < 0) fprintf (stderr, "%" PRId64 " WTF?!?\n", k);
         assert (count[k] >= 0);
         if (!(count[k] == 0 || count[k] == 2)) {
           OMP("omp critical") {
-            fprintf (stderr, "ughugh count[(%ld, %ld)]==%ld\n",
+            fprintf (stderr, "ughugh count[(%ld, %ld)]==%" PRId64 "\n",
                      (long)I(g, k), (long)J(g, k), count[k]);
             for (intvtx_t ki = 0; ki < NV; ++ki) {
               if (m[ki] == k)
@@ -369,7 +369,7 @@ rough_bucket_sort_el (const intvtx_t nv, const int64_t ne,
   OMP("omp for schedule(static)")
     for (intvtx_t k = 0; k < nv; ++k) {
       if (off[k] > off[k+1]) {
-        fprintf (stderr, "ugh %ld  [%ld, %ld)\n", (long)k, off[k], off[k+1]);
+        fprintf (stderr, "ugh %ld  [%" PRId64 ", %" PRId64 ")\n", (long)k, off[k], off[k+1]);
       }
       assert (off[k] <= off[k+1]);
     }
@@ -441,7 +441,7 @@ contract_el (int64_t NE, intvtx_t * restrict el /* 3 x oldNE */,
     OMP("omp barrier");
     w_out = all_calc_weight_base_flat (old_nv, NE, el, d);
     if (global_gwgt >= 0 && w_in != global_gwgt) {
-      fprintf (stderr, "%d/%d: %ld != %ld   %ld\n", omp_get_thread_num ()+1, omp_get_num_threads (),
+      fprintf (stderr, "%d/%d: %" PRId64 " != %" PRId64 "   %" PRId64 "\n", omp_get_thread_num ()+1, omp_get_num_threads (),
                w_in, global_gwgt, w_out);
     }
     OMP("omp master") assert (global_gwgt < 0 || w_in == global_gwgt);
@@ -529,7 +529,7 @@ contract_el (int64_t NE, intvtx_t * restrict el /* 3 x oldNE */,
       }
     OMP("omp master") {
       if (w_in != w_out) {
-        fprintf (stderr, "%d: w_in %ld w_out %ld\n",
+        fprintf (stderr, "%d: w_in %" PRId64 " w_out %" PRId64 "\n",
 #if defined(_OPENMP)
                  omp_get_thread_num (),
 #else
@@ -540,7 +540,7 @@ contract_el (int64_t NE, intvtx_t * restrict el /* 3 x oldNE */,
       assert (w_in == w_out);
 
       if (cutw_in != cutw_out) {
-        fprintf (stderr, "%d: cutw_in %ld cutw_out %ld\n",
+        fprintf (stderr, "%d: cutw_in %" PRId64 " cutw_out %" PRId64 "\n",
 #if defined(_OPENMP)
                  omp_get_thread_num (),
 #else
@@ -643,7 +643,7 @@ contract_el (int64_t NE, intvtx_t * restrict el /* 3 x oldNE */,
         for (int64_t k2 = count[new_i]; k2 < rowend[new_i]; ++k2)
           row_w_out += tmpcopy[1+2*k2];
         if (row_w_in != row_w_out)
-          fprintf (stderr, "row %ld mismatch %ld => %ld   %ld\n", (long)new_i,
+          fprintf (stderr, "row %ld mismatch %" PRId64 " => %" PRId64 "   %" PRId64 "\n", (long)new_i,
                    row_w_in, row_w_out, diagsum);
 #endif
       }
@@ -663,7 +663,7 @@ contract_el (int64_t NE, intvtx_t * restrict el /* 3 x oldNE */,
       }
     OMP("omp master")
       if (w_in != w_out) {
-        fprintf (stderr, "w_in %ld w_out %ld\n", w_in, w_out);
+        fprintf (stderr, "w_in %" PRId64 " w_out %" PRId64 "\n", w_in, w_out);
       }
     assert (w_in == w_out);
 #endif
@@ -688,7 +688,7 @@ contract_el (int64_t NE, intvtx_t * restrict el /* 3 x oldNE */,
       }
     OMP("omp master") {
       if (w_in != w_out) {
-        fprintf (stderr, "w_in %ld w_out %ld\n", w_in, w_out);
+        fprintf (stderr, "w_in %" PRId64 " w_out %" PRId64 "\n", w_in, w_out);
       }
     }
     assert (w_in == w_out);
@@ -700,7 +700,7 @@ contract_el (int64_t NE, intvtx_t * restrict el /* 3 x oldNE */,
     OMP("omp master") {
       cutw_out = 0;
       if (w_in != w_out) {
-        fprintf (stderr, "w_in %ld w_out %ld\n", w_in, w_out);
+        fprintf (stderr, "w_in %" PRId64 " w_out %" PRId64 "\n", w_in, w_out);
       }
     }
     OMP("omp barrier");
@@ -921,9 +921,9 @@ sliced_non_maximal_pass (const struct el g,
           if (m[i] != m[J(g, m[i])] || m[i] != m[I(g, m[i])]) {
             const intvtx_t j = J(g, m[i]);
             const intvtx_t actual_i = I(g, m[i]);
-            fprintf (stderr, "from %ld, attempted %ld = (%ld, %ld)[%g]\n",
+            fprintf (stderr, "from %ld, attempted %" PRId64 " = (%ld, %ld)[%g]\n",
                      (long)i, m[i], (long)actual_i, (long)j, s[m[i]]);
-            fprintf (stderr, "    m[%ld] = %ld (%ld, %ld)[%g], m[%ld] = %ld (%ld, %ld)[%g]\n",
+            fprintf (stderr, "    m[%ld] = %" PRId64 " (%ld, %ld)[%g], m[%ld] = %" PRId64 " (%ld, %ld)[%g]\n",
                      (long)actual_i, m[actual_i], (long)I(g, m[actual_i]), (long)J(g, m[actual_i]), s[m[actual_i]],
                      (long)j, m[j], (long)I(g, m[j]), (long)J(g, m[j]), s[j]);
           }
@@ -1032,7 +1032,7 @@ maximal_match_iter (const struct el g,
         const intvtx_t j = J(g, km);
         assert (i == actual_i || i == j);
         if (m[actual_i] != km) {
-          fprintf (stderr, "m[i]=m[%ld]=%ld m[actual_i]=m[%ld]=%ld m[j]=m[%ld]=%ld\n",
+          fprintf (stderr, "m[i]=m[%ld]=%" PRId64 " m[actual_i]=m[%ld]=%" PRId64 " m[j]=m[%ld]=%" PRId64 "\n",
                    (long)i, m[i], (long)actual_i, m[actual_i], (long)j, m[j]);
         }
         assert (m[actual_i] == km);
@@ -1434,7 +1434,7 @@ score_drop_size (double * restrict escore,
                  const int64_t maxsz,
                  const struct el g)
 {
-  const int64_t nv = g.nv;
+  /*const int64_t nv = g.nv;*/
   const int64_t ne = g.ne;
   CDECL(g);
 
@@ -1598,8 +1598,8 @@ community (int64_t * c, struct el * restrict g /* destructive */,
   double score_time = 0.0, match_time = 0.0, aftermatch_time = 0.0,
     contract_time = 0.0, other_time = 0.0;
 
-  const char *dump_fmt = NULL;
-  char dump_name[257];
+  /*const char *dump_fmt = NULL;*/
+  /*char dump_name[257];*/
 
   struct community_hist h;
 
@@ -1609,7 +1609,7 @@ community (int64_t * c, struct el * restrict g /* destructive */,
 
   /* fprintf (stderr, "ne_in %d\n", (int)ne_in); */
 
-  dump_fmt = getenv ("DUMP_FMT");
+  /*dump_fmt = getenv ("DUMP_FMT");*/
 
   assert (wslen > 3*nv_orig + ne_orig);
   m = ws;
@@ -1726,7 +1726,7 @@ community (int64_t * c, struct el * restrict g /* destructive */,
         if (tmax_score > max_score) max_score = tmax_score;
     }
     if (verbose) {
-      fprintf (stderr, "done : %ld, max score %g\n", nsteps, max_score);
+      fprintf (stderr, "done : %" PRId64 ", max score %g\n", nsteps, max_score);
     }
 
     if (decrease_factor > 0 && max_score < prev_max_score / decrease_factor) {
@@ -1977,8 +1977,8 @@ update_community (int64_t * restrict cmap_global, const int64_t nv_global,
   double score_time = 0.0, match_time = 0.0, aftermatch_time = 0.0,
     contract_time = 0.0, other_time = 0.0;
 
-  const char *dump_fmt = NULL;
-  char dump_name[257];
+  /*const char *dump_fmt = NULL;*/
+  /*char dump_name[257];*/
 
   struct community_hist h;
 
@@ -1988,7 +1988,7 @@ update_community (int64_t * restrict cmap_global, const int64_t nv_global,
 
   /* fprintf (stderr, "ne_in %d\n", (int)ne_in); */
 
-  dump_fmt = getenv ("DUMP_FMT");
+  /*dump_fmt = getenv ("DUMP_FMT");*/
 
   assert (wslen > 4*nv_orig + ne_orig);
   c = ws;
@@ -2094,7 +2094,7 @@ update_community (int64_t * restrict cmap_global, const int64_t nv_global,
         if (tmax_score > max_score) max_score = tmax_score;
     }
     if (verbose) {
-      fprintf (stderr, "done : %ld, max score %g\n", nsteps, max_score);
+      fprintf (stderr, "done : %" PRId64 ", max score %g\n", nsteps, max_score);
     }
 
     if (decrease_factor > 0 && max_score < prev_max_score / decrease_factor) {
@@ -2266,7 +2266,7 @@ update_community (int64_t * restrict cmap_global, const int64_t nv_global,
 
     assert (g->nv == new_nv);
 #if !defined(NDEBUG)
-    int64_t totsz = 0;
+    /*int64_t totsz = 0;*/
 #endif
     OMP("omp parallel") {
       OMP("omp for")
@@ -2504,7 +2504,7 @@ contract_self_el (int64_t NE, intvtx_t * restrict el /* 3 x oldNE */,
       }
     OMP("omp master") {
       if (w_in != w_out) {
-        fprintf (stderr, "%d: w_in %ld w_out %ld\n",
+        fprintf (stderr, "%d: w_in %" PRId64 " w_out %" PRId64 "\n",
 #if defined(_OPENMP)
                  omp_get_thread_num (),
 #else
@@ -2608,7 +2608,7 @@ contract_self_el (int64_t NE, intvtx_t * restrict el /* 3 x oldNE */,
         for (int64_t k2 = count[new_i]; k2 < rowend[new_i]; ++k2)
           row_w_out += tmpcopy[1+2*k2];
         if (row_w_in != row_w_out)
-          fprintf (stderr, "row %ld mismatch %ld => %ld   %ld\n", (long)new_i,
+          fprintf (stderr, "row %ld mismatch %" PRId64 " => %" PRId64 "   %" PRId64 "\n", (long)new_i,
                    row_w_in, row_w_out, diagsum);
 #endif
       }
@@ -2628,7 +2628,7 @@ contract_self_el (int64_t NE, intvtx_t * restrict el /* 3 x oldNE */,
       }
     OMP("omp master")
       if (w_in != w_out) {
-        fprintf (stderr, "w_in %ld w_out %ld\n", w_in, w_out);
+        fprintf (stderr, "w_in %" PRId64 " w_out %" PRId64 "\n", w_in, w_out);
       }
     assert (w_in == w_out);
 #endif
@@ -2653,7 +2653,7 @@ contract_self_el (int64_t NE, intvtx_t * restrict el /* 3 x oldNE */,
       }
     OMP("omp master") {
       if (w_in != w_out) {
-        fprintf (stderr, "w_in %ld w_out %ld\n", w_in, w_out);
+        fprintf (stderr, "w_in %" PRId64 " w_out %" PRId64 "\n", w_in, w_out);
       }
     }
     assert (w_in == w_out);
@@ -2664,7 +2664,7 @@ contract_self_el (int64_t NE, intvtx_t * restrict el /* 3 x oldNE */,
                                   rowstart, rowend);
     OMP("omp master") {
       if (w_in != w_out) {
-        fprintf (stderr, "w_in %ld w_out %ld\n", w_in, w_out);
+        fprintf (stderr, "w_in %" PRId64 " w_out %" PRId64 "\n", w_in, w_out);
       }
     }
     OMP("omp barrier");

--- a/src/clients/algorithms/simple_communities/src/graph-el.c
+++ b/src/clients/algorithms/simple_communities/src/graph-el.c
@@ -18,6 +18,8 @@
 #include <fcntl.h>
 #include <getopt.h>
 
+#include "compat/luc.h"
+
 #include "compat.h"
 #include "stinger_core/xmalloc.h"
 #include "graph-el.h"
@@ -197,7 +199,7 @@ el_snarf_graph (const char * fname,
                 struct el * g)
 {
   const uint64_t endian_check = 0x1234ABCDul;
-  size_t sz;
+  off_t sz;
   ssize_t ssz;
   int needs_bs = 0;
   int64_t nv, ne;
@@ -219,7 +221,7 @@ el_snarf_graph (const char * fname,
     }
     ssz = xread (fd, &hdr, sizeof (hdr));
     if (sizeof (hdr) != ssz) {
-      fprintf (stderr, "XXX: %zu %zd %zd\n", sizeof (hdr), ssz, SSIZE_MAX);
+      fprintf (stderr, "XXX: %zu %zd %ld\n", sizeof (hdr), ssz, SSIZE_MAX);
       perror ("Error reading initial graph header");
       abort ();
     }

--- a/src/clients/algorithms/spmspv_test/src/spmspv.c
+++ b/src/clients/algorithms/spmspv_test/src/spmspv.c
@@ -6,6 +6,7 @@
 
 #include "stinger_core/stinger_atomics.h"
 #include "stinger_core/stinger.h"
+#include "stinger_core/xmalloc.h"
 
 #include "compat.h"
 
@@ -28,7 +29,7 @@ static inline void setup_y (const int64_t nv, const double beta, double * y)
 /* It's a macro to avoid a sequence point that could force fetching x[i]... */
 #define ALPHAXI_VAL(alpha, xi) (alpha == 0.0? 0.0 : (alpha == 1.0? xi : (alpha == -1.0? -xi : (alpha * xi))))
 
-void stinger_dspmTv (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_dspmTv (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   setup_y (nv, beta, y);
 
@@ -42,7 +43,7 @@ void stinger_dspmTv (const int64_t nv, const double alpha, const struct stinger 
   }
 }
 
-void stinger_unit_dspmTv (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_unit_dspmTv (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   setup_y (nv, beta, y);
 
@@ -55,7 +56,7 @@ void stinger_unit_dspmTv (const int64_t nv, const double alpha, const struct sti
   }
 }
 
-static void setup_workspace (const int64_t nv, int64_t ** loc_ws, double ** val_ws)
+static void setup_workspace (const int64_t nv, int64_t * restrict * loc_ws, double * restrict * val_ws)
 {
   if (!*loc_ws) {
     *loc_ws = xmalloc (nv * sizeof (**loc_ws));
@@ -88,14 +89,14 @@ static void setup_sparse_y (const double beta,
   } else if (1.0 != beta) {
     for (int64_t k = 0; k < y_deg; ++k) {
       const int64_t i = y_idx[k];
-      const double yi = y_val[k];
+      /*const double yi = y_val[k];*/
       loc_ws[i] = k;
       y_val[k] = beta * y_val[k];
     }
   }
 }
 
-void stinger_dspmTspv (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_dspmTspv (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t y_deg = * y_deg_ptr;
   int64_t * restrict loc_ws = loc_ws_in;
@@ -126,7 +127,7 @@ void stinger_dspmTspv (const int64_t nv, const double alpha, const struct stinge
   *y_deg_ptr = y_deg;
 }
 
-void stinger_unit_dspmTspv (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_unit_dspmTspv (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t y_deg = * y_deg_ptr;
   int64_t * restrict loc_ws = loc_ws_in;

--- a/src/clients/algorithms/spmspv_test/src/spmspv_ompcas.c
+++ b/src/clients/algorithms/spmspv_test/src/spmspv_ompcas.c
@@ -94,7 +94,7 @@ static inline void setup_y (const int64_t nv, const double beta, double * y)
 #define DEGSCALE(axi, degi) (degi == 0? 0.0 : axi / degi);
 
 static inline void
-dspmTv_accum (const struct stinger * S, const int64_t i, const double alphaxi, double * y)
+dspmTv_accum (struct stinger * S, const int64_t i, const double alphaxi, double * y)
 {
   STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, i) {
     const int64_t j = STINGER_EDGE_DEST;
@@ -104,7 +104,7 @@ dspmTv_accum (const struct stinger * S, const int64_t i, const double alphaxi, d
 }
 
 static inline void
-dspmTv_unit_accum (const struct stinger * S, const int64_t i, const double alphaxi, double * y)
+dspmTv_unit_accum (struct stinger * S, const int64_t i, const double alphaxi, double * y)
 {
   STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, i) {
     const int64_t j = STINGER_EDGE_DEST;
@@ -112,7 +112,7 @@ dspmTv_unit_accum (const struct stinger * S, const int64_t i, const double alpha
   } STINGER_FORALL_OUT_EDGES_OF_VTX_END();
 }
 
-void stinger_dspmTv_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_dspmTv_ompcas (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel if(!omp_in_parallel())") {
     setup_y (nv, beta, y);
@@ -126,7 +126,7 @@ void stinger_dspmTv_ompcas (const int64_t nv, const double alpha, const struct s
   }
 }
 
-void stinger_unit_dspmTv_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_unit_dspmTv_ompcas (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel if(!omp_in_parallel())") {
     setup_y (nv, beta, y);
@@ -140,7 +140,7 @@ void stinger_unit_dspmTv_ompcas (const int64_t nv, const double alpha, const str
   }
 }
 
-void stinger_dspmTv_degscaled_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_dspmTv_degscaled_ompcas (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel if(!omp_in_parallel())") {
     setup_y (nv, beta, y);
@@ -157,7 +157,7 @@ void stinger_dspmTv_degscaled_ompcas (const int64_t nv, const double alpha, cons
   }
 }
 
-void stinger_unit_dspmTv_degscaled_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_unit_dspmTv_degscaled_ompcas (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel if(!omp_in_parallel())") {
     setup_y (nv, beta, y);
@@ -223,7 +223,7 @@ static void setup_sparse_y (const double beta,
     OMP("omp for")
       for (int64_t k = 0; k < y_deg; ++k) {
         const int64_t i = y_idx[k];
-        const double yi = y_val[k];
+        /*const double yi = y_val[k];*/
         loc_ws[i] = k;
         y_val[k] = beta * y_val[k];
       }
@@ -256,7 +256,7 @@ dspmTspv_y_idx_accum (const struct stinger * S,
 }
 
 static inline void
-dspmTspv_accum (const struct stinger * S, const int64_t i, const double alphaxi,
+dspmTspv_accum (struct stinger * S, const int64_t i, const double alphaxi,
                 int64_t * y_deg, int64_t * y_idx, double * y,
                 int64_t * loc_ws)
 {
@@ -269,7 +269,7 @@ dspmTspv_accum (const struct stinger * S, const int64_t i, const double alphaxi,
 }
 
 static inline void
-dspmTspv_unit_accum (const struct stinger * S, const int64_t i, const double alphaxi,
+dspmTspv_unit_accum (struct stinger * S, const int64_t i, const double alphaxi,
                      int64_t * y_deg, int64_t * y_idx, double * y,
                      int64_t * loc_ws)
 {
@@ -292,7 +292,7 @@ pack_vals (const int64_t y_deg, const int64_t * restrict y_idx,
     }
 }
 
-void stinger_dspmTspv_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_dspmTspv_ompcas (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;
@@ -319,7 +319,7 @@ void stinger_dspmTspv_ompcas (const int64_t nv, const double alpha, const struct
   }
 }
 
-void stinger_unit_dspmTspv_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_unit_dspmTspv_ompcas (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;
@@ -346,7 +346,7 @@ void stinger_unit_dspmTspv_ompcas (const int64_t nv, const double alpha, const s
   }
 }
 
-void stinger_dspmTspv_degscaled_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_dspmTspv_degscaled_ompcas (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;
@@ -376,7 +376,7 @@ void stinger_dspmTspv_degscaled_ompcas (const int64_t nv, const double alpha, co
   }
 }
 
-void stinger_unit_dspmTspv_degscaled_ompcas (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
+void stinger_unit_dspmTspv_degscaled_ompcas (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in /*UNUSED*/)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;

--- a/src/clients/algorithms/spmspv_test/src/spmspv_ompcas_batch.c
+++ b/src/clients/algorithms/spmspv_test/src/spmspv_ompcas_batch.c
@@ -94,7 +94,7 @@ static inline void setup_y (const int64_t nv, const double beta, double * y)
 #define DEGSCALE(axi, degi) (degi == 0? 0.0 : axi / degi);
 
 static inline void
-dspmTv_accum (const struct stinger * S, const int64_t i, const double alphaxi, double * y)
+dspmTv_accum (struct stinger * S, const int64_t i, const double alphaxi, double * y)
 {
   STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, i) {
     const int64_t j = STINGER_EDGE_DEST;
@@ -104,7 +104,7 @@ dspmTv_accum (const struct stinger * S, const int64_t i, const double alphaxi, d
 }
 
 static inline void
-dspmTv_unit_accum (const struct stinger * S, const int64_t i, const double alphaxi, double * y)
+dspmTv_unit_accum (struct stinger * S, const int64_t i, const double alphaxi, double * y)
 {
   STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, i) {
     const int64_t j = STINGER_EDGE_DEST;
@@ -112,7 +112,7 @@ dspmTv_unit_accum (const struct stinger * S, const int64_t i, const double alpha
   } STINGER_FORALL_OUT_EDGES_OF_VTX_END();
 }
 
-void stinger_dspmTv_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_dspmTv_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel if(!omp_in_parallel())") {
     setup_y (nv, beta, y);
@@ -126,7 +126,7 @@ void stinger_dspmTv_ompcas_batch (const int64_t nv, const double alpha, const st
   }
 }
 
-void stinger_unit_dspmTv_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_unit_dspmTv_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel if(!omp_in_parallel())") {
     setup_y (nv, beta, y);
@@ -140,7 +140,7 @@ void stinger_unit_dspmTv_ompcas_batch (const int64_t nv, const double alpha, con
   }
 }
 
-void stinger_dspmTv_degscaled_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_dspmTv_degscaled_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel if(!omp_in_parallel())") {
     setup_y (nv, beta, y);
@@ -157,7 +157,7 @@ void stinger_dspmTv_degscaled_ompcas_batch (const int64_t nv, const double alpha
   }
 }
 
-void stinger_unit_dspmTv_degscaled_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const double * x, const double beta, double * y)
+void stinger_unit_dspmTv_degscaled_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const double * x, const double beta, double * y)
 {
   OMP("omp parallel if(!omp_in_parallel())") {
     setup_y (nv, beta, y);
@@ -223,7 +223,7 @@ static void setup_sparse_y (const double beta,
     OMP("omp for")
       for (int64_t k = 0; k < y_deg; ++k) {
         const int64_t i = y_idx[k];
-        const double yi = y_val[k];
+        /*const double yi = y_val[k];*/
         loc_ws[i] = k;
         y_val[k] = beta * y_val[k];
       }
@@ -283,7 +283,7 @@ enqueue (struct batch * b, const int64_t j, int64_t * y_deg, int64_t * y_idx, in
 }
 
 static inline void
-dspmTspv_accum (const struct stinger * S, const int64_t i, const double alphaxi,
+dspmTspv_accum (struct stinger * S, const int64_t i, const double alphaxi,
                 int64_t * y_deg, int64_t * y_idx, double * y,
                 int64_t * loc_ws, struct batch *b)
 {
@@ -296,7 +296,7 @@ dspmTspv_accum (const struct stinger * S, const int64_t i, const double alphaxi,
 }
 
 static inline void
-dspmTspv_unit_accum (const struct stinger * S, const int64_t i, const double alphaxi,
+dspmTspv_unit_accum (struct stinger * S, const int64_t i, const double alphaxi,
                      int64_t * y_deg, int64_t * y_idx, double * y,
                      int64_t * loc_ws, struct batch *b)
 {
@@ -319,7 +319,7 @@ pack_vals (const int64_t y_deg, const int64_t * restrict y_idx,
     }
 }
 
-void stinger_dspmTspv_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
+void stinger_dspmTspv_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;
@@ -351,7 +351,7 @@ void stinger_dspmTspv_ompcas_batch (const int64_t nv, const double alpha, const 
   }
 }
 
-void stinger_unit_dspmTspv_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
+void stinger_unit_dspmTspv_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;
@@ -381,7 +381,7 @@ void stinger_unit_dspmTspv_ompcas_batch (const int64_t nv, const double alpha, c
   }
 }
 
-void stinger_dspmTspv_degscaled_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
+void stinger_dspmTspv_degscaled_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;
@@ -414,7 +414,7 @@ void stinger_dspmTspv_degscaled_ompcas_batch (const int64_t nv, const double alp
   }
 }
 
-void stinger_unit_dspmTspv_degscaled_ompcas_batch (const int64_t nv, const double alpha, const struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
+void stinger_unit_dspmTspv_degscaled_ompcas_batch (const int64_t nv, const double alpha, struct stinger *S, const int64_t x_deg, const int64_t * x_idx, const double * x_val, const double beta, int64_t * y_deg_ptr, int64_t * y_idx, double * y_val, int64_t * loc_ws_in, double * val_ws_in)
 {
   int64_t * loc_ws = loc_ws_in;
   double * val_ws = val_ws_in;

--- a/src/clients/algorithms/spmspv_test/src/spmspv_test.c
+++ b/src/clients/algorithms/spmspv_test/src/spmspv_test.c
@@ -56,7 +56,7 @@ static inline struct spvect alloc_spvect (int64_t nvmax);
 int
 main(int argc, char *argv[])
 {
-  double init_time, mult_time, gather_time, spmult_time;
+  double init_time, mult_time, gather_time = 0.0, spmult_time;
   double cwise_err, mult_cwise_err;
 
   int64_t nv;

--- a/src/clients/algorithms/static_components/src/static_components.c
+++ b/src/clients/algorithms/static_components/src/static_components.c
@@ -26,7 +26,7 @@ main(int argc, char *argv[])
     return -1;
   }
 
-  int64_t * components = (double *)alg->alg_data;
+  int64_t * components = (int64_t *)alg->alg_data;
 
   /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *
    * Initial static computation

--- a/src/clients/algorithms/streaming_connected_components/src/main.c
+++ b/src/clients/algorithms/streaming_connected_components/src/main.c
@@ -29,8 +29,8 @@ main (int argc, char *argv[])
   }
 
   bzero(alg->alg_data, sizeof(int64_t) * 2 * alg->stinger->max_nv);
-  int64_t * components = (int64_t *)alg->alg_data;
-  int64_t * component_size  = components + alg->stinger->max_nv;
+  /*int64_t * components = (int64_t *)alg->alg_data;*/
+  /*int64_t * component_size  = components + alg->stinger->max_nv;*/
 
 
 	stinger_scc_internal scc_internal;

--- a/src/clients/algorithms/test_alg/src/test_alg.cpp
+++ b/src/clients/algorithms/test_alg/src/test_alg.cpp
@@ -39,7 +39,7 @@ main(int argc, char *argv[])
 
   /* Print dependency storage information */
   for(int a = 0; a < argc - 4; a++) {
-    printf("Alg %s\nLoc %s\nDesc %s\nPtr %p\nData Per %ld\n",
+    printf("Alg %s\nLoc %s\nDesc %s\nPtr %p\nData Per %" PRId64 "\n",
       alg->dep_name[a], alg->dep_location[a], alg->dep_description[a], 
       alg->dep_data[a], alg->dep_data_per_vertex[a]);
   }
@@ -65,10 +65,10 @@ main(int argc, char *argv[])
       LOG_I_A("Preprocessing algorithm... consistency check: %ld",
 	(long) stinger_consistency_check(alg->stinger, alg->stinger->max_nv));
 
-      LOG_I_A("Preprocessing algorithm... num_insertions: %ld",
+      LOG_I_A("Preprocessing algorithm... num_insertions: %" PRId64,
 	alg->num_insertions);
       for(int64_t i = 0; i < alg->num_insertions; i++) {
-	LOG_I_A("\tINS: TYPE %s %ld FROM %s %ld TO %s %ld WEIGHT %ld TIME %ld", 
+	LOG_I_A("\tINS: TYPE %s %" PRId64 " FROM %s %" PRId64 " TO %s %" PRId64 " WEIGHT %" PRId64 " TIME %" PRId64, 
 	  alg->insertions[i].type_str,
 	  alg->insertions[i].type,
 	  alg->insertions[i].source_str,
@@ -79,10 +79,10 @@ main(int argc, char *argv[])
 	  alg->insertions[i].time);
       }
 
-      LOG_I_A("Preprocessing algorithm... num_deletions: %ld",
+      LOG_I_A("Preprocessing algorithm... num_deletions: %" PRId64,
 	alg->num_deletions);
       for(int64_t i = 0; i < alg->num_deletions; i++) {
-	LOG_I_A("\tDEL: TYPE %s %ld FROM %s %ld TO %s %ld",
+	LOG_I_A("\tDEL: TYPE %s %" PRId64 " FROM %s %" PRId64 " TO %s %" PRId64,
 	  alg->deletions[i].type_str,
 	  alg->deletions[i].type,
 	  alg->deletions[i].source_str,
@@ -100,10 +100,10 @@ main(int argc, char *argv[])
       LOG_I_A("Postprocessing algorithm... consistency check: %ld",
 	(long) stinger_consistency_check(alg->stinger, alg->stinger->max_nv));
 
-      LOG_I_A("Postprocessing algorithm... num_insertions: %ld",
+      LOG_I_A("Postprocessing algorithm... num_insertions: %" PRId64,
 	alg->num_insertions);
       for(int64_t i = 0; i < alg->num_insertions; i++) {
-	LOG_I_A("\tINS: TYPE %s %ld FROM %s %ld TO %s %ld WEIGHT %ld TIME %ld", 
+	LOG_I_A("\tINS: TYPE %s %" PRId64 " FROM %s %" PRId64 " TO %s %" PRId64 " WEIGHT %" PRId64 " TIME %" PRId64, 
 	  alg->insertions[i].type_str,
 	  alg->insertions[i].type,
 	  alg->insertions[i].source_str,
@@ -114,10 +114,10 @@ main(int argc, char *argv[])
 	  alg->insertions[i].time);
       }
 
-      LOG_I_A("Postprocessing algorithm... num_deletions: %ld",
+      LOG_I_A("Postprocessing algorithm... num_deletions: %" PRId64,
 	alg->num_deletions);
       for(int64_t i = 0; i < alg->num_deletions; i++) {
-	LOG_I_A("\tDEL: TYPE %s %ld FROM %s %ld TO %s %ld",
+	LOG_I_A("\tDEL: TYPE %s %" PRId64 " FROM %s %" PRId64 " TO %s %" PRId64,
 	  alg->deletions[i].type_str,
 	  alg->deletions[i].type,
 	  alg->deletions[i].source_str,

--- a/src/clients/streams/csv_stream/inc/explore_csv.h
+++ b/src/clients/streams/csv_stream/inc/explore_csv.h
@@ -45,11 +45,11 @@ struct EdgeCollection;
 struct ExploreCSVGeneric {
   ExploreCSVGeneric * child;
   ExploreCSVGeneric() : child(NULL) {}
-  ~ExploreCSVGeneric() { if (child) delete child; }
+  virtual ~ExploreCSVGeneric() { if (child) delete child; }
 
-  virtual bool operator()(EdgeCollection & edges, char ** fields, int64_t * lengths, int64_t count, char * field) { LOG_E("Error, this is a generic object"); }
+  virtual bool operator()(EdgeCollection & edges, char ** fields, int64_t * lengths, int64_t count, char * field) { LOG_E("Error, this is a generic object"); return false; }
   virtual void print() { LOG_E("Error, this is a generic object"); }
-  virtual ExploreCSVGeneric * copy(path_type_t path) { LOG_E("Error, this is a generic object"); }
+  virtual ExploreCSVGeneric * copy(path_type_t path) { LOG_E("Error, this is a generic object"); return NULL; }
 };
 
 struct EdgeCollection {
@@ -305,7 +305,7 @@ struct EdgeCollection {
     /* TODO figure out what to do about missing fields */
     for(int64_t i = 0; i < start.size(); i++) {
       if(!(*start[i])(*this, fields, lengths, count, NULL)) {
-	LOG_E_A("Index %ld skipped", i);
+	LOG_E_A("Index %" PRId64 " skipped", i);
 	return 0;
       }
     }
@@ -906,7 +906,7 @@ struct ExploreCSVRow : public ExploreCSVGeneric {
     if(index < count) {
       return (*child)(edges, fields, lengths, count, fields[index]);
     } else {
-      LOG_W_A("skipping - Column index (%ld) is greater than number of columns (%ld)", index, count);
+      LOG_W_A("skipping - Column index (%" PRId64 ") is greater than number of columns (%" PRId64 ")", index, count);
       return false;
     }
   }
@@ -915,7 +915,7 @@ struct ExploreCSVRow : public ExploreCSVGeneric {
     if(index == -1)
       printf("@.");
     else
-      printf("@.%ld.", index);
+      printf("@.%" PRId64 ".", index);
     if(child)
       child->print();
     else

--- a/src/clients/streams/csv_stream/src/main.cpp
+++ b/src/clients/streams/csv_stream/src/main.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <cstring>
+#include <cinttypes>
 #include <sys/types.h>
 #include <time.h>
 #include <netdb.h>
@@ -27,7 +28,7 @@ main(int argc, char *argv[])
   int port = 10102;
   int batch_size = 1000;
   double timeout = 0;
-  char * hostname = NULL;
+  char const * hostname = NULL;
   char * filename = NULL;
   int use_directed = 0;
 
@@ -120,7 +121,7 @@ main(int argc, char *argv[])
     timesince += toc();
     int64_t total_actions = batch.insertions_size() + batch.deletions_size();
     if(total_actions >= batch_size || (timeout > 0 && timesince >= timeout)) {
-      LOG_I_A("Sending a batch of %ld actions", total_actions);
+      LOG_I_A("Sending a batch of %" PRId64 " actions", total_actions);
       send_message(sock_handle, batch);
       timesince = 0;
       batch.Clear();
@@ -136,7 +137,7 @@ main(int argc, char *argv[])
 
   int64_t total_actions = batch.insertions_size() + batch.deletions_size();
   if(total_actions) {
-    LOG_I_A("Sending a batch of %ld actions", total_actions);
+    LOG_I_A("Sending a batch of %" PRId64 " actions", total_actions);
     send_message(sock_handle, batch);
   }
 

--- a/src/clients/streams/human_edge_generator/src/main.cpp
+++ b/src/clients/streams/human_edge_generator/src/main.cpp
@@ -22,7 +22,7 @@ main(int argc, char *argv[])
 {
   /* global options */
   int port = 10102;
-  char * hostname = NULL;
+  char const * hostname = NULL;
 
   int opt = 0;
   while(-1 != (opt = getopt(argc, argv, "p:a:"))) {
@@ -81,7 +81,7 @@ main(int argc, char *argv[])
     insertion->set_weight(1);
     insertion->set_time(time);
 
-    LOG_I_A ("%ld: <%s, %s> at time %ld", batch_num, src.c_str(), dest.c_str(), time);
+    LOG_I_A ("%" PRId64 ": <%s, %s> at time %" PRId64, batch_num, src.c_str(), dest.c_str(), time);
     LOG_D ("Sending message");
     send_message(sock_handle, batch);
 

--- a/src/clients/streams/json_stream/inc/explore_json.h
+++ b/src/clients/streams/json_stream/inc/explore_json.h
@@ -78,6 +78,7 @@ month(const char * month) {
 	      } break;
 
   }
+  return -1;
 }
 
 #define CHAR2INT(X) ((X) - '0')
@@ -171,11 +172,11 @@ struct EdgeCollection;
 struct ExploreJSONGeneric {
   ExploreJSONGeneric * child;
   ExploreJSONGeneric() : child(NULL) {}
-  ~ExploreJSONGeneric() { if (child) delete child; }
+  virtual ~ExploreJSONGeneric() { if (child) delete child; }
 
-  virtual bool operator()(EdgeCollection & edges, rapidjson::Value & document) { LOG_E("Error, this is a generic object"); }
+  virtual bool operator()(EdgeCollection & edges, rapidjson::Value & document) { LOG_E("Error, this is a generic object"); return false; }
   virtual void print() { LOG_E("Error, this is a generic object"); }
-  virtual ExploreJSONGeneric * copy(path_type_t path) { LOG_E("Error, this is a generic object"); }
+  virtual ExploreJSONGeneric * copy(path_type_t path) { LOG_E("Error, this is a generic object"); return NULL; }
 };
 
 struct EdgeCollection {
@@ -1057,7 +1058,7 @@ struct ExploreJSONArray : public ExploreJSONGeneric {
 
   virtual bool operator()(EdgeCollection & edges, rapidjson::Value & document) {
     if(document.IsArray()) {
-      if(index == -1) {
+      if(index == rapidjson::SizeType(-1)) {
 	for(rapidjson::SizeType i = 0; i < document.Size(); i++) {
 	  return (*child)(edges, document[i]);
 	}
@@ -1067,10 +1068,11 @@ struct ExploreJSONArray : public ExploreJSONGeneric {
     } else {
       return false;
     }
+    return false;
   }
 
   virtual void print() {
-    if(index == -1)
+    if(index == rapidjson::SizeType(-1))
       printf("@.");
     else
       printf("@.%ld.", (long) index);

--- a/src/clients/streams/json_stream/src/main.cpp
+++ b/src/clients/streams/json_stream/src/main.cpp
@@ -20,7 +20,7 @@ main(int argc, char *argv[])
   int port = 10102;
   int batch_size = 1000;
   double timeout = 0;
-  char * hostname = NULL;
+  char const * hostname = NULL;
   char * filename = NULL;
   int use_directed = 0;
 
@@ -111,7 +111,7 @@ main(int argc, char *argv[])
     timesince += toc();
     int64_t total_actions = batch.insertions_size() + batch.deletions_size();
     if(total_actions >= batch_size || (timeout > 0 && timesince >= timeout)) {
-      LOG_I_A("Sending a batch of %ld actions", total_actions);
+      LOG_I_A("Sending a batch of %" PRId64 " actions", total_actions);
       send_message(sock_handle, batch);
       timesince = 0;
       batch.Clear();
@@ -128,7 +128,7 @@ main(int argc, char *argv[])
 
   int64_t total_actions = batch.insertions_size() + batch.deletions_size();
   if(total_actions) {
-    LOG_I_A("Sending a batch of %ld actions", total_actions);
+    LOG_I_A("Sending a batch of %" PRId64 " actions", total_actions);
     send_message(sock_handle, batch);
   }
 

--- a/src/clients/streams/mongodb_stream/src/main.cpp
+++ b/src/clients/streams/mongodb_stream/src/main.cpp
@@ -29,7 +29,7 @@ main(int argc, char *argv[])
   int mongo_port = 13001;
   int batch_size = 100000;
   int num_batches = -1;
-  char * stinger_hostname = NULL;
+  char const * stinger_hostname = NULL;
   char mongo_server[256];
   mongo_server[0] = '\0';
 
@@ -93,6 +93,7 @@ main(int argc, char *argv[])
       case MONGO_CONN_NO_SOCKET:  printf( "no socket\n" ); return 1;
       case MONGO_CONN_FAIL:       printf( "connection failed\n" ); return 1;
       case MONGO_CONN_NOT_MASTER: printf( "not master\n" ); return 1;
+      default:                    printf( "unhandled error\n" ); return 1;
     }
   }
   /* End Mongo */
@@ -109,8 +110,8 @@ main(int argc, char *argv[])
 
 #endif
   /* actually generate and send the batches */
-  char * buf = NULL, ** fields = NULL;
-  uint64_t bufSize = 0, * lengths = NULL, fieldsSize = 0, count = 0;
+  /*char * buf = NULL, ** fields = NULL;
+  uint64_t bufSize = 0, * lengths = NULL, fieldsSize = 0, count = 0;*/
   int64_t line = 0;
   int batch_num = 0;
   int skip_num = 0;
@@ -147,7 +148,7 @@ main(int argc, char *argv[])
 
     int64_t print_header = 1;
     while (mongo_cursor_next(&cursor) == MONGO_OK) {
-      const char * source_vtx;
+      const char * source_vtx = NULL;
       skip_num++;   // this helps us recover if we get a partial batch from Mongo
 
       /* "postedTime" tells us when this occured (as a string) */

--- a/src/clients/streams/netflow_stream/src/main.cpp
+++ b/src/clients/streams/netflow_stream/src/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
 {
 	/* global options */
 	int port = 10102;
-	char * hostname = NULL;
+	char const * hostname = NULL;
 
 	int opt = 0;
 	uint64_t batch_time = 0;
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
 	if(batch_size == 0){
 		batch_size = NETFLOW_BATCH_SIZE;
 	}
-	LOG_D_A ("Sending batches every %d seconds", batch_time);
+	LOG_D_A ("Sending batches every %" PRIu64 " seconds", batch_time);
 
 	/* start the connection */
 	int sock_handle = connect_to_server (hostname, port);
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
 	/* actually generate and send the batches */
 	int64_t batch_num = 0;
 
-	int line_count;
+	/*int line_count;*/
 	char *result;
 	char input_line[MAX_LINE];
 	std::string line;
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 	std::vector<EdgeInsertion> batch_buffer;
 
 	int64_t insertIdx =0;
-	int64_t edgeIdx =0;
+	/*int64_t edgeIdx =0;*/
 
 	double global_start = dpc_tic();
 	double start = dpc_tic();
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
 			if (batch_num == 0 || batch_num % batch_size == 0) {
 				int batch_size = batch.insertions_size() + batch.deletions_size();
 				LOG_D ("Sending message");
-				LOG_D_A ("%ld: %d actions. EX: %s:<%s, %s> (w: %d) at time %ld", batch_num, batch_size, p.protocol.c_str(), p.src.c_str(), p.dest.c_str(), p.bytes, p.time);
+				LOG_D_A ("%" PRId64 ": %d actions. EX: %s:<%s, %s> (w: %d) at time %" PRId64, batch_num, batch_size, p.protocol.c_str(), p.src.c_str(), p.dest.c_str(), p.bytes, p.time);
 				send_message(sock_handle, batch);
 				batch.clear_insertions();
 				batch_num++;
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
 			if(timeInSeconds > batch_time){
 				int batch_size = batch.insertions_size() + batch.deletions_size();
 				// LOG_D_A ("%f Seconds, %ld Batches", timeInSeconds, batch_num);
-				LOG_D_A ("%ld: %d actions. EX: %s:<%s, %s> (w: %d) at time %ld after %f seconds", batch_num, batch_size, p.protocol.c_str(), p.src.c_str(), p.dest.c_str(), p.bytes, p.time, dpc_toc(start));
+				LOG_D_A ("%" PRId64 ": %d actions. EX: %s:<%s, %s> (w: %d) at time %" PRId64 " after %f seconds", batch_num, batch_size, p.protocol.c_str(), p.src.c_str(), p.dest.c_str(), p.bytes, p.time, dpc_toc(start));
 				send_message(sock_handle, batch);
 				batch.clear_insertions();
 				batch_buffer.clear();
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
 		insertIdx++;
 	}
 
-	LOG_D_A("Sent %ld batches in %f seconds. Constructing last batch from buffer ", batch_num, dpc_toc(global_start));
+	LOG_D_A("Sent %" PRId64 " batches in %f seconds. Constructing last batch from buffer ", batch_num, dpc_toc(global_start));
 
 	batch.clear_insertions();
 	for (std::vector<EdgeInsertion>::iterator it = batch_buffer.begin() ; it != batch_buffer.end(); ++it) {
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
 	}
 
 	send_message(sock_handle, batch);
-	LOG_D_A("Sent %ld messages from buffer. Total time: %f",batch_buffer.size(), dpc_toc(global_start));
+	LOG_D_A("Sent %zu messages from buffer. Total time: %f",batch_buffer.size(), dpc_toc(global_start));
 
 	return 0;
 }

--- a/src/clients/streams/random_edge_generator/src/main.cpp
+++ b/src/clients/streams/random_edge_generator/src/main.cpp
@@ -31,7 +31,7 @@ using namespace gt::stinger;
 #define E_A(X,...) fprintf(stderr, "%s %s %d:\n\t" #X "\n", __FILE__, __func__, __LINE__, __VA_ARGS__);
 #define E(X) E_A(X,NULL)
 #define V_A(X,...) fprintf(stdout, "%s %s %d:\n\t" #X "\n", __FILE__, __func__, __LINE__, __VA_ARGS__);
-#define V(X) V_A(X,NULL)
+#define V(X) fprintf(stdout, "%s %s %d:\n\t" #X "\n", __FILE__, __func__, __LINE__);
 
 #define DEFAULT_SEED 0x9367
 
@@ -46,7 +46,7 @@ main(int argc, char *argv[])
   int is_int = 0;
   int delay = 2;
   long seed = DEFAULT_SEED;
-  char * hostname = NULL;
+  char const * hostname = NULL;
 
   int opt = 0;
   while(-1 != (opt = getopt(argc, argv, "p:b:a:x:y:n:is:d:"))) {
@@ -88,7 +88,7 @@ main(int argc, char *argv[])
       case '?':
       case 'h': {
 	printf("Usage:    %s [-p port] [-a server_addr] [-n num_vertices] [-x batch_size] [-y num_batches] [-i] [-s seed] [-d delay]\n", argv[0]);
-	printf("Defaults:\n\tport: %d\n\tserver: localhost\n\tnum_vertices: %d\n -i forces the use of integers in place of strings\n", port, nv);
+	printf("Defaults:\n\tport: %d\n\tserver: localhost\n\tnum_vertices: %" PRIu64 "\n -i forces the use of integers in place of strings\n", port, nv);
 	exit(0);
       } break;
     }
@@ -111,13 +111,13 @@ main(int argc, char *argv[])
   if (sock_handle == -1) exit(-1);
 
   /* actually generate and send the batches */
-  char * buf = NULL, ** fields = NULL;
-  uint64_t bufSize = 0, * lengths = NULL, fieldsSize = 0, count = 0;
+  /*char * buf = NULL, ** fields = NULL;
+  uint64_t bufSize = 0, * lengths = NULL, fieldsSize = 0, count = 0;*/
   int64_t line = 0;
   int batch_num = 0;
 
   srand48 (seed);
-  const ldiv_t nv_breakup = ldiv (INT64_MAX, nv);
+  const lldiv_t nv_breakup = lldiv (INT64_MAX, nv);
 
   while(1) {
     StingerBatch batch;

--- a/src/clients/streams/rmat_edge_generator/src/main.cpp
+++ b/src/clients/streams/rmat_edge_generator/src/main.cpp
@@ -23,7 +23,7 @@ using namespace gt::stinger;
 #define E_A(X,...) fprintf(stderr, "%s %s %d:\n\t" #X "\n", __FILE__, __func__, __LINE__, __VA_ARGS__);
 #define E(X) E_A(X,NULL)
 #define V_A(X,...) fprintf(stdout, "%s %s %d:\n\t" #X "\n", __FILE__, __func__, __LINE__, __VA_ARGS__);
-#define V(X) V_A(X,NULL)
+#define V(X) fprintf(stdout, "%s %s %d:\n\t" #X "\n", __FILE__, __func__, __LINE__);
 
 
 int
@@ -35,7 +35,7 @@ main(int argc, char *argv[])
   int num_batches = -1;
   int nv = 1024;
   int is_int = 0;
-  char * hostname = NULL;
+  char const * hostname = NULL;
 
   int opt = 0;
   while(-1 != (opt = getopt(argc, argv, "p:a:x:y:n:i"))) {

--- a/src/clients/tools/alg_to_mongo/src/alg_handling.cpp
+++ b/src/clients/tools/alg_to_mongo/src/alg_handling.cpp
@@ -74,7 +74,7 @@ array_to_bson   (
 
     /* the description string is space-delimited */
     char * placeholder;
-    char * ptr = strtok_r (tmp, " ", &placeholder);
+    (void) strtok_r (tmp, " ", &placeholder);
 
     /* skip the formatting */
     char * pch = strtok_r (NULL, " ", &placeholder);

--- a/src/clients/tools/alg_to_mongo/src/main.cpp
+++ b/src/clients/tools/alg_to_mongo/src/main.cpp
@@ -75,6 +75,7 @@ int main (int argc, char *argv[])
       case MONGO_CONN_NO_SOCKET:  printf( "no socket\n" ); return 1;
       case MONGO_CONN_FAIL:       printf( "connection failed\n" ); return 1;
       case MONGO_CONN_NOT_MASTER: printf( "not master\n" ); return 1;
+      default:                    printf( "unhandled error\n" ); return 1;
     }
   }
   /* End MongoDB connect */
@@ -101,7 +102,7 @@ int main (int argc, char *argv[])
     mon.wait_for_sync();
 
     int64_t cur_time = get_current_timestamp();
-    LOG_D_A ("Processing timestamp %ld", cur_time);
+    LOG_D_A ("Processing timestamp %" PRId64, cur_time);
     tic();
 
     /* Get the STINGER pointer -- critical section */
@@ -147,7 +148,7 @@ int main (int argc, char *argv[])
   
     double time = toc();
     LOG_I_A ("elapsed: %20.15e sec", time);
-    LOG_I_A ("nv: %ld", nv);
+    LOG_I_A ("nv: %" PRId64, nv);
     LOG_I_A ("rate: %20.15e vtx/sec", (double) nv / time);
 
 

--- a/src/clients/tools/dump_graph_to_disk/src/main.cpp
+++ b/src/clients/tools/dump_graph_to_disk/src/main.cpp
@@ -80,7 +80,7 @@ int main (int argc, char *argv[])
 
   for (int64_t i = 0; i < nv; i++) {
     STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, i) {
-      fprintf(fp, "%ld %ld %ld %ld %ld %ld\n",  STINGER_EDGE_SOURCE, 
+      fprintf(fp, "%" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 "\n",  STINGER_EDGE_SOURCE, 
 					    STINGER_EDGE_DEST,
 					    STINGER_EDGE_TYPE,
 					    STINGER_EDGE_WEIGHT,
@@ -95,8 +95,8 @@ int main (int argc, char *argv[])
 
   double time = toc();
   LOG_I_A ("elapsed: %20.15e sec", time);
-  LOG_I_A ("nv: %ld", nv);
-  LOG_I_A ("ne: %ld", ne);
+  LOG_I_A ("nv: %" PRId64, nv);
+  LOG_I_A ("ne: %" PRId64, ne);
   LOG_I_A ("rate: %20.15e edges/sec", (double) ne / time);
 
 

--- a/src/clients/tools/json_rpc_server/inc/rpc_state.h
+++ b/src/clients/tools/json_rpc_server/inc/rpc_state.h
@@ -54,6 +54,7 @@ namespace gt {
 
       virtual int64_t operator()(rapidjson::Value * params, rapidjson::Value & result, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator) {
 	LOG_W("This is a generic JSON_RPCFunction object and should not be called");
+        return -1;
       }
 
       bool contains_params(rpc_params_t * p, rapidjson::Value * params);
@@ -69,24 +70,29 @@ namespace gt {
 	JSON_RPCServerState * server_state;
 
       public:
-	JSON_RPCSession(int64_t sess_id, JSON_RPCServerState * state) : session_id(sess_id), the_lock(0), server_state(state) { }
+	JSON_RPCSession(int64_t sess_id, JSON_RPCServerState * state) : the_lock(0), session_id(sess_id), server_state(state) { }
+	virtual ~JSON_RPCSession() { }
 	void lock();
 	void unlock();
 	virtual rpc_params_t * get_params() {
 	  LOG_W("This is a generic JSON_RPCSession object and should not be called");
+	  return NULL;
 	};
 	virtual int64_t update(const StingerBatch & batch) {
 	  LOG_W("This is a generic JSON_RPCSession object and should not be called");
+          return -1;
 	}
 	virtual int64_t onRegister(
 				rapidjson::Value & result,
 				rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator) {
 	  LOG_W("This is a generic JSON_RPCSession object and should not be called");
+          return -1;
 	}
 	virtual int64_t onRequest(
 				rapidjson::Value & result,
 				rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator) {
 	  LOG_W("This is a generic JSON_RPCSession object and should not be called");
+          return -1;
 	}
 	virtual JSON_RPCSession * gimme(int64_t sess_id, JSON_RPCServerState * state) {
 	  LOG_W("This is a generic JSON_RPCSession object and should not be called");

--- a/src/clients/tools/json_rpc_server/src/array_to_json_monolithic.cpp
+++ b/src/clients/tools/json_rpc_server/src/array_to_json_monolithic.cpp
@@ -101,7 +101,7 @@ array_to_json_monolithic   (json_rpc_array_meth_t method, stinger_t * S,
   /* Bounds checking */
   if (method == SET) {
     if (set_len < 1) {
-      LOG_E_A("Invalid set length: %ld.", set_len);
+      LOG_E_A("Invalid set length: %" PRId64 ".", set_len);
     }
     if (!set) {
       LOG_E("Vertex set is null.");
@@ -109,11 +109,11 @@ array_to_json_monolithic   (json_rpc_array_meth_t method, stinger_t * S,
   }
   if (method == SORTED || method == RANGE) {
     if (start >= nv) {
-      LOG_E_A("Invalid range: %ld to %ld. Expecting [0, %ld).", start, end, nv);
+      LOG_E_A("Invalid range: %" PRId64 " to %" PRId64 ". Expecting [0, %" PRId64 ").", start, end, nv);
       return json_rpc_error(-32602, rtn, allocator);
     }
     if (end > nv) {
-      LOG_W_A("Invalid end of range: %ld. Expecting less than %ld.", end, nv);
+      LOG_W_A("Invalid end of range: %" PRId64 ". Expecting less than %" PRId64 ".", end, nv);
       end = nv;
     }
   }
@@ -122,11 +122,11 @@ array_to_json_monolithic   (json_rpc_array_meth_t method, stinger_t * S,
     return json_rpc_error(-32603, rtn, allocator);
   }
   if (stride <= 0) {
-    LOG_W_A("Stride of %ld is not allowed. Fixing.", stride);
+    LOG_W_A("Stride of %" PRId64 " is not allowed. Fixing.", stride);
     stride = 1;
   }
   if (stride >= nv) {
-    LOG_W_A("Stride of %ld only returns one value. This probably isn't what you want.", stride);
+    LOG_W_A("Stride of %" PRId64 " only returns one value. This probably isn't what you want.", stride);
   }
   if (vtypes != NULL && num_vtypes <= 0) {
     LOG_W("Number of vertex types specified as <= 0. Assuming all vertex types");
@@ -135,7 +135,7 @@ array_to_json_monolithic   (json_rpc_array_meth_t method, stinger_t * S,
 
   MAP_STING(S);
   
-  bool asc;
+  bool asc = false;
   if (method == SORTED) {
     if (strncmp(order_str, "ASC", 3)==0) {
       asc = true;
@@ -167,7 +167,7 @@ array_to_json_monolithic   (json_rpc_array_meth_t method, stinger_t * S,
 
   /* the description string is space-delimited */
   char * placeholder;
-  char * ptr = strtok_r (tmp, " ", &placeholder);
+  (void) strtok_r (tmp, " ", &placeholder);
 
   /* skip the formatting */
   char * pch = strtok_r (NULL, " ", &placeholder);
@@ -184,7 +184,7 @@ array_to_json_monolithic   (json_rpc_array_meth_t method, stinger_t * S,
     LOG_D_A ("%s: begin while :: %s", search_string, pch);
     if (strcmp(pch, search_string) == 0) {
       LOG_D_A ("%s: matches", search_string);
-      int64_t * idx;
+      int64_t * idx = NULL;
       if (method == SORTED) {
         switch (description_string[off]) {
           case 'f':
@@ -234,9 +234,9 @@ array_to_json_monolithic   (json_rpc_array_meth_t method, stinger_t * S,
           } 
         }
 
-        int64_t vtx;
-        if (method == SORTED)
-          vtx = idx[(int64_t)i];
+	int64_t vtx = -1;
+	if (method == SORTED)
+		vtx = idx[(int64_t)i];
         if (method == RANGE)
           vtx = i;
         if (method == SET)

--- a/src/clients/tools/json_rpc_server/src/array_to_json_reduction.cpp
+++ b/src/clients/tools/json_rpc_server/src/array_to_json_reduction.cpp
@@ -25,7 +25,7 @@ array_to_json_reduction    (stinger_t * S,
 
   /* the description string is space-delimited */
   char * placeholder;
-  char * ptr = strtok_r (tmp, " ", &placeholder);
+  (void) strtok_r (tmp, " ", &placeholder);
 
   /* skip the formatting */
   char * pch = strtok_r (NULL, " ", &placeholder);

--- a/src/clients/tools/json_rpc_server/src/egonet.cpp
+++ b/src/clients/tools/json_rpc_server/src/egonet.cpp
@@ -109,8 +109,8 @@ JSON_RPC_egonet::operator()(rapidjson::Value * params, rapidjson::Value & result
       vtypes.PushBack(vtype, allocator);
 
       if (strings) {
-        char * name = NULL;
-        uint64_t len = 0;
+        /*char * name = NULL;
+        uint64_t len = 0;*/
         char * vtype_name = stinger_vtype_names_lookup_name(S, source_type);
         vtype_str.SetString(vtype_name, strlen(vtype_name), allocator);
         vtypes_str.PushBack(vtype_str, allocator);
@@ -181,8 +181,8 @@ JSON_RPC_egonet::operator()(rapidjson::Value * params, rapidjson::Value & result
       vtypes.PushBack(vtype, allocator);
 
       if (strings) {
-        char * name = NULL;
-        uint64_t len = 0;
+        /*char * name = NULL;
+        uint64_t len = 0;*/
         char * vtype_name = stinger_vtype_names_lookup_name(S, source_type);
         vtype_str.SetString(vtype_name, strlen(vtype_name), allocator);
         vtypes_str.PushBack(vtype_str, allocator);

--- a/src/clients/tools/json_rpc_server/src/exact_diameter.cpp
+++ b/src/clients/tools/json_rpc_server/src/exact_diameter.cpp
@@ -46,7 +46,7 @@ JSON_RPC_exact_diameter::operator()(rapidjson::Value * params, rapidjson::Value 
 
     double * pr = (double *)xcalloc(S->max_nv,sizeof(double));
     OMP("omp parallel for")
-    for(uint64_t i = 0; i < vertices.len; i++) {
+    for(int64_t i = 0; i < vertices.len; i++) {
         pr[vertices.arr[i]] = 1 / ((double)vertices.len);
     }
 
@@ -73,7 +73,7 @@ JSON_RPC_exact_diameter::operator()(rapidjson::Value * params, rapidjson::Value 
     rapidjson::Value vtx_str (rapidjson::kArrayType);
     rapidjson::Value vtx_phys;
 
-    for (uint64_t i = 0; i < vertices.len; i++) {
+    for (int64_t i = 0; i < vertices.len; i++) {
         uint64_t vtx = vertices.arr[i];
         vertex_id_json.PushBack(vtx,allocator);
         value_json.PushBack(pr[vtx],allocator);

--- a/src/clients/tools/json_rpc_server/src/get_connected_component.cpp
+++ b/src/clients/tools/json_rpc_server/src/get_connected_component.cpp
@@ -44,7 +44,7 @@ JSON_RPC_get_connected_component::operator()(rapidjson::Value * params, rapidjso
  
   /* read-only data arrays */
   int64_t * component_map = (int64_t *)alg_state->data;
-  int64_t * component_size  = component_map + S->max_nv;
+  /*int64_t * component_size  = component_map + S->max_nv;*/
 
   rapidjson::Value src, src_str;
   rapidjson::Value component_id, component_id_str;

--- a/src/clients/tools/json_rpc_server/src/get_data_description.cpp
+++ b/src/clients/tools/json_rpc_server/src/get_data_description.cpp
@@ -22,7 +22,7 @@ description_string_to_json (const char * description_string,
 
   /* the description string is space-delimited */
   char * placeholder;
-  char * ptr = strtok_r (tmp, " ", &placeholder);
+  (void) strtok_r (tmp, " ", &placeholder);
 
   /* skip the formatting */
   char * pch = strtok_r (NULL, " ", &placeholder);

--- a/src/clients/tools/json_rpc_server/src/get_server_health.cpp
+++ b/src/clients/tools/json_rpc_server/src/get_server_health.cpp
@@ -18,7 +18,7 @@ using namespace gt::stinger;
 
 static int get_loadavg (rapidjson::Value & result, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator);
 static int get_time (rapidjson::Value & result, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator);
-static int get_rpc_methods (rapidjson::Value & result, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator);
+static void get_rpc_methods (rapidjson::Value & result, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator);
 static int get_uptime (rapidjson::Value & result, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator);
 
 
@@ -260,7 +260,7 @@ get_time (rapidjson::Value & result, rapidjson::MemoryPoolAllocator<rapidjson::C
   return 0;
 }
 
-static int
+static void
 get_rpc_methods (rapidjson::Value & result, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator)
 {
   std::map<std::string, JSON_RPCFunction *>::iterator it;

--- a/src/clients/tools/json_rpc_server/src/json_rpc.cpp
+++ b/src/clients/tools/json_rpc_server/src/json_rpc.cpp
@@ -95,13 +95,13 @@ json_rpc_process_request (rapidjson::Document& document, rapidjson::Document& re
 
   /* Is the id field a number or a string */
   /* Get the id field */
-  int64_t id_int;
-  const char * id_str;
+  /*int64_t id_int;*/
+  /*const char * id_str;*/
   if (document["id"].IsInt64()) {
-    id_int = document["id"].GetInt64();
+    /*id_int = document["id"].GetInt64();*/
   }
   else if (document["id"].IsString()) {
-    id_str = (const char *) document["id"].GetString();
+    /*id_str = (const char *) document["id"].GetString();*/
   }
   else {
     response.AddMember("jsonrpc", "2.0", allocator);

--- a/src/clients/tools/json_rpc_server/src/json_rpc_server.cpp
+++ b/src/clients/tools/json_rpc_server/src/json_rpc_server.cpp
@@ -71,7 +71,7 @@ create_error(rapidjson::Document& response)
 static int
 begin_request_handler(struct mg_connection *conn)
 {
-  init_timer;
+  init_timer();
   double time = timer();
 
   const struct mg_request_info *request_info = mg_get_request_info(conn);
@@ -88,8 +88,8 @@ begin_request_handler(struct mg_connection *conn)
     uint8_t * storage = (uint8_t *) xcalloc (1, MAX_REQUEST_SIZE);
 
     int64_t read = mg_read(conn, storage, MAX_REQUEST_SIZE);
-    if (read > MAX_REQUEST_SIZE-2) {
-      LOG_E_A("Request was too large: %ld", read);
+    if (read > ((int64_t) (MAX_REQUEST_SIZE-2))) {
+      LOG_E_A("Request was too large: %" PRId64, read);
       
       /* send an error back */
       create_error(output);
@@ -181,7 +181,7 @@ main (int argc, char ** argv)
   mon_connect(10103, "localhost", "json_rpc");
 
   /* Mongoose setup and start */
-  struct mg_context *ctx;
+  /*struct mg_context *ctx;*/
   struct mg_callbacks callbacks;
 
   // List of options. Last element must be NULL.
@@ -192,7 +192,7 @@ main (int argc, char ** argv)
   callbacks.begin_request = begin_request_handler;
 
   // Start the web server.
-  ctx = mg_start(&callbacks, NULL, opts);
+  (void) mg_start(&callbacks, NULL, opts);
   
   /* infinite loop */
   if(unleash_daemon) {

--- a/src/clients/tools/json_rpc_server/src/pagerank_subgraph.cpp
+++ b/src/clients/tools/json_rpc_server/src/pagerank_subgraph.cpp
@@ -45,7 +45,7 @@ JSON_RPC_pagerank_subgraph::operator()(rapidjson::Value * params, rapidjson::Val
 
   double * pr = (double *)xcalloc(S->max_nv,sizeof(double));
   OMP("omp parallel for")
-  for(uint64_t i = 0; i < vertices.len; i++) {
+  for(int64_t i = 0; i < vertices.len; i++) {
     pr[vertices.arr[i]] = 1 / ((double)vertices.len);
   }
 
@@ -69,7 +69,7 @@ JSON_RPC_pagerank_subgraph::operator()(rapidjson::Value * params, rapidjson::Val
   rapidjson::Value vtx_str (rapidjson::kArrayType);
   rapidjson::Value vtx_phys;
 
-  for (uint64_t i = 0; i < vertices.len; i++) {
+  for (int64_t i = 0; i < vertices.len; i++) {
     uint64_t vtx = vertices.arr[i];
     vertex_id_json.PushBack(vtx,allocator);
     value_json.PushBack(pr[vtx],allocator);

--- a/src/clients/tools/json_rpc_server/src/rpc_state.cpp
+++ b/src/clients/tools/json_rpc_server/src/rpc_state.cpp
@@ -19,8 +19,7 @@ JSON_RPCServerState::get_server_state() {
 }
 
 JSON_RPCServerState::JSON_RPCServerState() :
-  next_session_id(1), session_lock(0),
-  max_sessions(20), StingerMon() {
+  session_lock(0), max_sessions(20), next_session_id(1) {
     time(&start_time);
 }
 
@@ -144,6 +143,8 @@ JSON_RPCFunction::contains_params(rpc_params_t * p, rapidjson::Value * params) {
             ptr->arr = NULL;
           }
           break;
+          default:
+          break;
         }
       } else {
         return false;
@@ -154,7 +155,7 @@ JSON_RPCFunction::contains_params(rpc_params_t * p, rapidjson::Value * params) {
         case TYPE_VERTEX: {
           if((*params)[p->name].IsInt64()) {
             int64_t tmp = (*params)[p->name].GetInt64();
-            if (tmp < 0 || tmp >= S->max_nv)
+            if (tmp < 0 || tmp >= ((int64_t) S->max_nv))
               return false;
             *((int64_t *)p->output) = tmp;
           } else if((*params)[p->name].IsString()) {
@@ -170,7 +171,7 @@ JSON_RPCFunction::contains_params(rpc_params_t * p, rapidjson::Value * params) {
         case TYPE_EDGE_TYPE: {
           if((*params)[p->name].IsInt64()) {
             int64_t tmp = (*params)[p->name].GetInt64();
-            if (tmp < 0 || tmp >= S->max_netypes)
+            if (tmp < 0 || tmp >= ((int64_t) S->max_netypes))
               return false;
             *((int64_t *)p->output) = tmp;
           } else if((*params)[p->name].IsString()) {
@@ -186,7 +187,7 @@ JSON_RPCFunction::contains_params(rpc_params_t * p, rapidjson::Value * params) {
         case TYPE_VERTEX_TYPE: {
           if((*params)[p->name].IsInt64()) {
             int64_t tmp = (*params)[p->name].GetInt64();
-            if (tmp < 0 || tmp >= S->max_nvtypes)
+            if (tmp < 0 || tmp >= ((int64_t) S->max_nvtypes))
               return false;
             *((int64_t *)p->output) = tmp;
           } else if((*params)[p->name].IsString()) {
@@ -239,7 +240,7 @@ JSON_RPCFunction::contains_params(rpc_params_t * p, rapidjson::Value * params) {
 	  for (int64_t i = 0; i < ptr->len; i++) {
 	    if ((*params)[p->name][i].IsInt64()) {
 	      int64_t tmp = (*params)[p->name][i].GetInt64();
-	      if ( !(tmp < 0 || tmp >= S->max_nv) ) {
+	      if ( !(tmp < 0 || tmp >= ((int64_t) S->max_nv)) ) {
 		ptr->arr[count_valid++] = tmp;
 	      }
 	    }
@@ -252,6 +253,8 @@ JSON_RPCFunction::contains_params(rpc_params_t * p, rapidjson::Value * params) {
 	  }
 	  ptr->len = count_valid;
         }
+        break;
+        default:
         break;
       }
     }

--- a/src/clients/tools/json_rpc_server/src/session_handling.cpp
+++ b/src/clients/tools/json_rpc_server/src/session_handling.cpp
@@ -45,7 +45,7 @@ JSON_RPC_community_subgraph::update(const StingerBatch & batch)
 
   /* TODO: this does not take "undirected batch" into account */
 
-  for(size_t d = 0; d < batch.deletions_size(); d++) {
+  for(int d = 0; d < batch.deletions_size(); d++) {
     const EdgeDeletion & del = batch.deletions(d);
 
     int64_t src = del.source();
@@ -61,7 +61,7 @@ JSON_RPC_community_subgraph::update(const StingerBatch & batch)
 
   /* edge insertions whose endpoints are within the same community get sent
      to the client on the next request */
-  for (size_t i = 0; i < batch.insertions_size(); i++) {
+  for (int i = 0; i < batch.insertions_size(); i++) {
     const EdgeInsertion & in = batch.insertions(i);
     
     int64_t src = in.source();
@@ -235,7 +235,7 @@ JSON_RPC_community_subgraph::onRegister(
   }
 
   /* Get the community label of the source vertex */
-  int64_t community_id = _data->get_int64(_source);
+  (void) _data->get_int64(_source);
 
   /* Add all vertices with the same label to the vertices[] set */
   for (int64_t i = 0; i < _data->length(); i++) {
@@ -308,7 +308,7 @@ description_string_to_pointer (gt::stinger::JSON_RPCServerState * server_state,
   strcpy(tmp, description_string);
 
   /* the description string is space-delimited */
-  char * ptr = strtok (tmp, " ");
+  (void) strtok (tmp, " ");
 
   /* skip the formatting */
   char * pch = strtok (NULL, " ");
@@ -380,7 +380,7 @@ JSON_RPC_vertex_event_notifier::update(const StingerBatch & batch)
 
   /* TODO: this does not take "undirected batch" into account */
 
-  for(size_t d = 0; d < batch.deletions_size(); d++) {
+  for(int d = 0; d < batch.deletions_size(); d++) {
     const EdgeDeletion & del = batch.deletions(d);
 
     int64_t src = del.source();
@@ -394,7 +394,7 @@ JSON_RPC_vertex_event_notifier::update(const StingerBatch & batch)
     }
   }
 
-  for(size_t d = 0; d < batch.insertions_size(); d++) {
+  for(int d = 0; d < batch.insertions_size(); d++) {
     const EdgeInsertion & in = batch.insertions(d);
 
     int64_t src = in.source();
@@ -684,7 +684,7 @@ JSON_RPC_get_latlon::onRequest(
 	      rapidjson::Value & result,
 	      rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator)
 {
-  stinger_t * S = server_state->get_stinger();
+  (void) server_state->get_stinger();
   rapidjson::Value coord, lat, lon, pair;
   std::set<std::pair<double, double> >::iterator it;
 
@@ -810,7 +810,7 @@ JSON_RPC_get_latlon_gnip::onRequest(
 	      rapidjson::Value & result,
 	      rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator)
 {
-  stinger_t * S = server_state->get_stinger();
+  (void) server_state->get_stinger();
   rapidjson::Value coord, lat, lon, sentiment, categories, pair;
   std::set<semantic_coordinates>::iterator it;
 
@@ -943,7 +943,7 @@ JSON_RPC_get_latlon_twitter::onRequest(
 	      rapidjson::Value & result,
 	      rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator)
 {
-  stinger_t * S = server_state->get_stinger();
+  (void) server_state->get_stinger();
   rapidjson::Value coord, ref, lat, lon, sentiment, categories, pair;
   std::set<semantic_coordinates>::iterator it;
 

--- a/src/clients/tools/scrape_alg_data/src/scrape_mmap.c
+++ b/src/clients/tools/scrape_alg_data/src/scrape_mmap.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[]) {
     }
 
     int64_t offset = 0;
-    while(token = strtok_r(ptr, " ", &rest)) {
+    while((token = strtok_r(ptr, " ", &rest))) {
       if(0 == strcmp(argv[2], token) || (offset_mode && offset == atol(argv[2]))) {
 	break;
       } else {

--- a/src/clients/tools/sql_client/src/execution.cpp
+++ b/src/clients/tools/sql_client/src/execution.cpp
@@ -25,7 +25,7 @@ execute_query (query_plan_t * query, stinger_t * S)
   printf("\n");
 
   int64_t limit = query->limit;
-  int64_t offset = query->offset;
+  /*int64_t offset = query->offset;*/
   int64_t rows = 0;
   int64_t valid = 0;  /* track number of valid rows, for limit/offset clauses */
   int64_t nv = S->max_nv;
@@ -68,7 +68,7 @@ execute_query (query_plan_t * query, stinger_t * S)
 	}
       }
 
-      if (flag = resolve_predicates (query))
+      if ((flag = resolve_predicates (query)))
 	valid++;
     }
     else {
@@ -147,6 +147,7 @@ evaluate_where_operator (int64_t a, operator_t op, int64_t b)
     case LTE:	  return a <= b;
     case LESS:	  return a < b;
     case NOT_EQUAL: return a != b;
+    default: break;
   }
 
   return 0;

--- a/src/clients/tools/sql_client/src/parser.cpp
+++ b/src/clients/tools/sql_client/src/parser.cpp
@@ -13,8 +13,8 @@ parse_query (char * input, query_plan_t * query)
 {
   state_t cur_state = SELECT;
   state_t next_state;
-  int where_and = 0;
-  int where_or = 0;
+  /*int where_and = 0;
+  int where_or = 0;*/
   char buf[30];
   char * token;
   char * saveptr;
@@ -121,7 +121,7 @@ parse_query (char * input, query_plan_t * query)
 		    {
 		      //printf(":: WHERE_VAL\n");
 
-		      while (token = strtok_r (NULL, " ,", &saveptr)) {
+		      while ((token = strtok_r (NULL, " ,", &saveptr))) {
 			if (token && strncasecmp(token, "ORDER", 5) == 0) {
 			  token = strtok_r (NULL, " ,", &saveptr);
 			  next_state = ORDERBY;
@@ -188,7 +188,7 @@ parse_query (char * input, query_plan_t * query)
 		      int64_t limit_number;
 		      //printf(":: LIMIT\n");
 		      query->activate_limit = 1;
-		      sscanf(token, "%ld", &limit_number);
+		      sscanf(token, "%" SCNd64, &limit_number);
 		      query->limit = limit_number;
 		      //printf("%ld\n", (long) limit_number);
 
@@ -209,7 +209,7 @@ parse_query (char * input, query_plan_t * query)
 		      int64_t offset_number;
 		      //printf(":: OFFSET\n");
 		      if (token) {
-			sscanf(token, "%ld", &offset_number);
+			sscanf(token, "%" SCNd64, &offset_number);
 			query->offset = offset_number;
 			//printf("%ld\n", (long) offset_number);
 			next_state = DONE;
@@ -301,7 +301,7 @@ parse_where_expr (char * expr, query_plan_t * query)
   char op_str[3];
   int64_t value;
   char * token;
-  char * saveptr;
+  /*char * saveptr;*/
   //printf("expr is: %s\n", expr);
 
   std::stack<int> mystack;
@@ -340,7 +340,7 @@ parse_where_expr (char * expr, query_plan_t * query)
 
     /* if the item is a "number", add it directly */
     else if (token[0] != '(' && token[0] != ')') {
-      sscanf(token, "%[^'()=<>'] %[^0123456789] %ld", buf, op_str, &value);
+      sscanf(token, "%[^'()=<>'] %[^0123456789] %" SCNd64, buf, op_str, &value);
       operator_t op = select_operator (op_str);
       //printf("field_name: %s, %s, %ld\n", buf, op_str, value);
 

--- a/src/clients/tools/sql_client/src/sql_parser.cpp
+++ b/src/clients/tools/sql_client/src/sql_parser.cpp
@@ -28,7 +28,7 @@ int main (int argc, char *argv[])
 
   StingerMon & mon = StingerMon::get_mon();
 
-  int64_t num_algs = mon.get_num_algs();
+  (void) mon.get_num_algs();
   //printf("num_algs = %ld\n", (long) num_algs);
   
   /* Parse the query and form a plan */

--- a/src/server/inc/server.h
+++ b/src/server/inc/server.h
@@ -22,11 +22,11 @@ start_alg_handling (void *);
 
 
 /* global variables */
-static bool dropped_vertices = false;
+/*static bool dropped_vertices = false;
 static int64_t n_components, n_nonsingleton_components, max_compsize;
 static int64_t min_batch_ts, max_batch_ts;
 static int64_t * comp_vlist;
-static int64_t * comp_mark;
+static int64_t * comp_mark;*/
 
 
 /* utility functions */
@@ -62,6 +62,7 @@ vertex_string (const T& in, std::string& out)
   std::transform(out.begin(), out.end(), out.begin(), ascii_tolower);
 }
 
+#if 0
 static void
 split_day_in_year (int diy, int * month, int * dom)
 {
@@ -110,5 +111,6 @@ ts_to_str (int64_t ts_in, char * out, size_t len)
 	    (pst? 'S' : 'D'),
 	    dom, month_name[month]);
 }
+#endif /* 0 */
 
 #endif  /* _SERVER_H */

--- a/src/server/src/alg_handling.cpp
+++ b/src/server/src/alg_handling.cpp
@@ -97,11 +97,11 @@ handle_alg(struct AcceptedSock * sock, StingerServerState & server_state)
 
       if(data_total) {
         sprintf(map_name, "/%s", alg_to_server.alg_name().c_str());
-        LOG_D_A("Attempting to map %ld at %s", data_total, map_name);
+        LOG_D_A("Attempting to map %" PRId64 " at %s", data_total, map_name);
         data = shmmap(map_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR, PROT_READ | PROT_WRITE, data_total, MAP_SHARED);
 
         if(!data) {
-          LOG_E_A("Error, mapping storage for algorithm %s failed (%ld bytes per vertex)", 
+          LOG_E_A("Error, mapping storage for algorithm %s failed (%" PRId64 " bytes per vertex)", 
             alg_to_server.alg_name().c_str(), alg_to_server.data_per_vertex());
           server_to_alg.set_result(ALG_FAILURE_GENERIC);
           send_message(sock->handle, server_to_alg);
@@ -124,7 +124,7 @@ handle_alg(struct AcceptedSock * sock, StingerServerState & server_state)
       LOG_D("Resolving dependencies")
 
       int64_t max_level = 0;
-      bool deps_resolved = true;
+      /*bool deps_resolved = true;*/
       for(int64_t i = 0; i < alg_to_server.req_dep_name_size(); i++) {
         const std::string & req_dep_name = alg_to_server.req_dep_name(i);
         if(server_state.has_alg(req_dep_name)) {
@@ -146,7 +146,7 @@ handle_alg(struct AcceptedSock * sock, StingerServerState & server_state)
           server_to_alg.set_action(alg_to_server.action());
           server_to_alg.set_result(ALG_FAILURE_DEPENDENCY);
 
-          deps_resolved = false;
+          /*deps_resolved = false;*/
                 shmunmap(map_name, data, data_total);
                 shmunlink(map_name);
 
@@ -157,7 +157,7 @@ handle_alg(struct AcceptedSock * sock, StingerServerState & server_state)
 
       alg_state->level = max_level;
 
-      LOG_V_A("Adding algorithm %s at level %ld", alg_to_server.alg_name().c_str(), max_level);
+      LOG_V_A("Adding algorithm %s at level %" PRId64, alg_to_server.alg_name().c_str(), max_level);
 
       server_to_alg.set_alg_num(server_state.add_alg(max_level, alg_state));
 
@@ -495,7 +495,7 @@ process_loop_handler(void * data)
     process_batch(server_state.get_stinger(), *batch);
     update_time = timer() - update_time;
     int64_t edge_count = batch->insertions_size() + batch->deletions_size();
-    LOG_I_A("Server processed %ld edges in %20.15e seconds", edge_count, update_time);
+    LOG_I_A("Server processed %" PRId64 " edges in %20.15e seconds", edge_count, update_time);
     LOG_I_A("%f edges per second", ((double) edge_count) / update_time);
 
     /* update performance stats */

--- a/src/server/src/batch.cpp
+++ b/src/server/src/batch.cpp
@@ -131,7 +131,7 @@ template <int64_t type>
 void process_insertions(stinger_t * S, StingerBatch & batch)
 {
     OMP("omp parallel for")
-    for (size_t i = 0; i < batch.insertions_size(); i++)
+    for (int i = 0; i < batch.insertions_size(); i++)
     {
         EdgeInsertion & in = *batch.mutable_insertions(i);
         int64_t u = -1, v = -1;
@@ -153,7 +153,7 @@ void process_insertions(stinger_t * S, StingerBatch & batch)
     }
 
     OMP("omp parallel for")
-    for (size_t i = 0; i < batch.insertions_size(); i++)
+    for (int i = 0; i < batch.insertions_size(); i++)
     {
         EdgeInsertion & in = *batch.mutable_insertions(i);
         if (in.result() == -1)
@@ -161,13 +161,13 @@ void process_insertions(stinger_t * S, StingerBatch & batch)
             switch (type)
             {
                 case NUMBERS_ONLY:
-                    LOG_E_A("Error inserting edge <%ld, %ld>", in.source(), in.destination());
+                    LOG_E_A("Error inserting edge <%" PRId64 ", %" PRId64 ">", in.source(), in.destination());
                     break;
                 case STRINGS_ONLY:
                     LOG_E_A("Error inserting edge <%s, %s>", in.source_str().c_str(), in.destination_str().c_str());
                     break;
                 case MIXED:
-                    LOG_E_A("Error inserting edge <%ld - %s, %ld - %s>",
+                    LOG_E_A("Error inserting edge <%" PRId64 " - %s, %" PRId64 " - %s>",
                         in.source(), in.source_str().c_str(), in.destination(), in.destination_str().c_str());
                     break;
                 default:
@@ -198,7 +198,7 @@ template <int64_t type>
 void process_deletions(stinger_t * S, StingerBatch & batch){
 
     OMP("omp parallel for")
-    for(size_t d = 0; d < batch.deletions_size(); d++)
+    for(int d = 0; d < batch.deletions_size(); d++)
     {
         EdgeDeletion & del = *batch.mutable_deletions(d);
         // Look up src/dst ID from string, if necessary
@@ -264,13 +264,13 @@ void process_deletions(stinger_t * S, StingerBatch & batch){
                 switch (type)
                 {
                     case NUMBERS_ONLY:
-                        LOG_E_A("Error removing edge <%ld, %ld>", del.source(), del.destination());
+                        LOG_E_A("Error removing edge <%" PRId64 ", %" PRId64 ">", del.source(), del.destination());
                         break;
                     case STRINGS_ONLY:
                         LOG_E_A("Error removing edge <%s, %s>", del.source_str().c_str(), del.destination_str().c_str());
                         break;
                     case MIXED:
-                        LOG_E_A("Error removing edge <%ld - %s, %ld - %s>",
+                        LOG_E_A("Error removing edge <%" PRId64 " - %s, %" PRId64 " - %s>",
                                 u, del.source_str().c_str(), v, del.destination_str().c_str());
                         break;
                     default:
@@ -300,7 +300,7 @@ void process_deletions(stinger_t * S, StingerBatch & batch){
 template <int64_t type>
 void process_vertex_updates(stinger_t * S, StingerBatch & batch){
     OMP("omp for")
-    for(size_t d = 0; d < batch.vertex_updates_size(); d++) {
+    for(int d = 0; d < batch.vertex_updates_size(); d++) {
         VertexUpdate & vup = *batch.mutable_vertex_updates(d);
         handle_vertex_names_types<type>(vup, S);
     }

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -170,22 +170,22 @@ int main(int argc, char *argv[])
     const char * memory_size_cfg;
 
     if (cfg.lookupValue("num_vertices", nv_cfg)) {
-      LOG_D_A("num_vertices: %ld",nv_cfg);
+      LOG_D_A("num_vertices: %lld",nv_cfg);
       stinger_config->nv = nv_cfg;
     }
     if (cfg.lookupValue("edges_per_type", edge_factor_cfg)) {
-      LOG_D_A("edges_per_type: %ld",edge_factor_cfg);
+      LOG_D_A("edges_per_type: %lld",edge_factor_cfg);
       stinger_config->nebs = ceil((double)edge_factor_cfg / STINGER_EDGEBLOCKSIZE);
       if (stinger_config->nebs < stinger_config->nv) {
         stinger_config->nebs = stinger_config->nv;
       }
     }
     if (cfg.lookupValue("num_edge_types", netypes_cfg)) {
-      LOG_D_A("num_edge_types: %ld",netypes_cfg);
+      LOG_D_A("num_edge_types: %d",netypes_cfg);
       stinger_config->netypes = netypes_cfg;
     }
     if (cfg.lookupValue("num_vertex_types", nvtypes_cfg)) {
-      LOG_D_A("num_vertex_types: %ld",nvtypes_cfg);
+      LOG_D_A("num_vertex_types: %d",nvtypes_cfg);
       stinger_config->nvtypes = nvtypes_cfg;
     }
     if (cfg.exists("edge_type_names")) {
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
       stinger_config->no_map_none_etype = true;
     }
     if (cfg.lookupValue("map_none_etype", map_none_etype_cfg)) {
-      LOG_D_A("map_none_etype: %ld",map_none_etype_cfg);
+      LOG_D_A("map_none_etype: %d",map_none_etype_cfg);
       stinger_config->no_map_none_etype = !map_none_etype_cfg;
     }
     if (cfg.exists("vertex_type_names")) {
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
       stinger_config->no_map_none_vtype = true;
     }
     if (cfg.lookupValue("map_none_vtype", map_none_vtype_cfg)) {
-      LOG_D_A("map_none_vtype: %ld",map_none_vtype_cfg);
+      LOG_D_A("map_none_vtype: %d",map_none_vtype_cfg);
       stinger_config->no_map_none_vtype = !map_none_vtype_cfg;
     }
     if (cfg.lookupValue("max_memsize", memory_size_cfg)) {  
@@ -231,7 +231,7 @@ int main(int argc, char *argv[])
         stinger_config->memory_size = mx;
     }
     if (cfg.lookupValue("no_resize", no_resize_cfg)) {
-      LOG_D_A("no_resize: %ld",no_resize_cfg);
+      LOG_D_A("no_resize: %d",no_resize_cfg);
       stinger_config->no_resize = no_resize_cfg;
     }
   }
@@ -330,14 +330,14 @@ int main(int argc, char *argv[])
     int64_t etype_names_len = etype_names.getLength();
     int64_t remaining_types = (stinger_config->no_map_none_etype) ? stinger_config->netypes : stinger_config->netypes - 1;
     if (stinger_config->netypes && etype_names_len > remaining_types) {
-      LOG_E_A("Too many edge types specified. %ld specified %ld remaining.", etype_names_len, remaining_types);
+      LOG_E_A("Too many edge types specified. %" PRId64 " specified %" PRId64 " remaining.", etype_names_len, remaining_types);
       etype_names_len = remaining_types;
     }
     int64_t tmp = 0;
     for (int i = 0; i < etype_names_len; i++) {
       const char * type_name = etype_names[i];
       stinger_etype_names_create_type(S, type_name, &tmp);
-      LOG_D_A("Mapped %s to %ld",type_name,tmp);
+      LOG_D_A("Mapped %s to %" PRId64,type_name,tmp);
     }
   }
   if (cfg.exists("vertex_type_names")) {
@@ -345,14 +345,14 @@ int main(int argc, char *argv[])
     int64_t vtype_names_len = vtype_names.getLength();
     int64_t remaining_types = (stinger_config->no_map_none_vtype) ? stinger_config->nvtypes : stinger_config->nvtypes - 1;
     if (stinger_config->nvtypes && vtype_names_len > remaining_types) {
-      LOG_E_A("Too many vertex types specified. %ld specified %ld remaining.", vtype_names_len, remaining_types);
+      LOG_E_A("Too many vertex types specified. %" PRId64 " specified %" PRId64 " remaining.", vtype_names_len, remaining_types);
       vtype_names_len = remaining_types;
     }
     int64_t tmp = 0;
     for (int i = 0; i < vtype_names_len; i++) {
       const char * type_name = vtype_names[i];
       stinger_vtype_names_create_type(S, type_name, &tmp);
-      LOG_D_A("Mapped %s to %ld",type_name,tmp);
+      LOG_D_A("Mapped %s to %" PRId64,type_name,tmp);
     }
   }
   xfree(stinger_config);
@@ -360,8 +360,8 @@ int main(int argc, char *argv[])
 
   LOG_V("Graph created. Running stats...");
   tic();
-  LOG_V_A("Vertices: %ld", stinger_num_active_vertices(S));
-  LOG_V_A("Edges: %ld", stinger_total_edges(S));
+  LOG_V_A("Vertices: %" PRId64, stinger_num_active_vertices(S));
+  LOG_V_A("Edges: %" PRId64, stinger_total_edges(S));
 
   /* consistency check */
   LOG_V_A("Consistency %ld", (long) stinger_consistency_check(S, S->max_nv));
@@ -433,7 +433,7 @@ cleanup (void)
     /* snapshot to disk */
     if (save_to_disk) {
       int64_t rtn = stinger_save_to_file(S, stinger_max_active_vertex(S) + 1, input_file);
-      LOG_D_A("save_to_file return code: %ld",rtn);
+      LOG_D_A("save_to_file return code: %" PRId64,rtn);
     }
 
     /* clean up */

--- a/src/tests/independent_sets_test/independent_sets_test.cpp
+++ b/src/tests/independent_sets_test/independent_sets_test.cpp
@@ -47,14 +47,14 @@ TEST_F(IndependentTest, simple_directed) {
             STINGER_FORALL_OUT_EDGES_OF_VTX_BEGIN(S, v){
                                         if(iset[STINGER_EDGE_DEST]){
                                             //FAIL
-                                            printf("%ld => %ld \n", v, STINGER_EDGE_DEST);
+                                            printf("%" PRId64 " => %" PRId64 " \n", v, STINGER_EDGE_DEST);
                                             ASSERT_EQ(0,1);
                                         }
                                     }STINGER_FORALL_OUT_EDGES_OF_VTX_END();
             STINGER_FORALL_IN_EDGES_OF_VTX_BEGIN(S, v){
                                         if(iset[STINGER_EDGE_DEST]){
                                             //FAIL
-                                            printf("%ld => %ld \n", v, STINGER_EDGE_DEST);
+                                            printf("%" PRId64 " => %" PRId64 " \n", v, STINGER_EDGE_DEST);
                                             ASSERT_EQ(0,1);
                                         }
                                     }STINGER_FORALL_IN_EDGES_OF_VTX_END();

--- a/src/tests/names_test/stinger_names_test.cpp
+++ b/src/tests/names_test/stinger_names_test.cpp
@@ -18,7 +18,7 @@ protected:
 TEST_F(StingerNamesTest, create_names) {
   int64_t out = 0;
   
-  char * test_names [] = {
+  char const * test_names [] = {
       "Alpha",
       "Beta",
       "Gamma",
@@ -41,7 +41,7 @@ TEST_F(StingerNamesTest, create_names) {
 TEST_F(StingerNamesTest, overflow_create_names) {
   int64_t out = 0;
   
-  char * test_names [] = {
+  char const * test_names [] = {
       "Alpha",
       "Beta",
       "Gamma",
@@ -131,7 +131,7 @@ TEST_F(StingerNamesTest, lookup_failure) {
 TEST_F(StingerNamesTest, resize) {
   int64_t out = 0;
   
-  char * test_names [] = {
+  char const * test_names [] = {
       "Alpha",
       "Beta",
       "Gamma",

--- a/src/tests/pagerank_test/directed_princeton.cpp
+++ b/src/tests/pagerank_test/directed_princeton.cpp
@@ -49,7 +49,7 @@ TEST_F(PagerankPrincetonTest, DirectedPagerank) {
 
   double tol = 0.001;
 
-  for (int64_t v=0; v < stinger_max_active_vertex(S) + 1; v++) {
+  for (uint64_t v=0; v < stinger_max_active_vertex(S) + 1; v++) {
     EXPECT_NEAR(expected_pr[v],pr[v],tol);
   }
 
@@ -88,7 +88,7 @@ TEST_F(PagerankPrincetonTest, PagerankSubset) {
 
   double tol = 0.001;
 
-  for (int64_t v=0; v < stinger_max_active_vertex(S) + 1; v++) {
+  for (uint64_t v=0; v < stinger_max_active_vertex(S) + 1; v++) {
     if (v < 4) {
       EXPECT_NEAR(expected_pr[v],pr[v],tol);
     } else {
@@ -113,7 +113,7 @@ TEST_F(PagerankPrincetonTest, PagerankDirectedType) {
   tmp_pr = (double *)xcalloc(nv, sizeof(double));
   pr = (double *)xcalloc(nv, sizeof(double));
 
-  for(uint64_t v = 0; v < nv; v++) {
+  for(int64_t v = 0; v < nv; v++) {
     pr[v] = 1 / ((double)nv);
   }
 
@@ -131,7 +131,7 @@ TEST_F(PagerankPrincetonTest, PagerankDirectedType) {
 
   double leftover = 1.0;
 
-  for (int64_t v=0; v < stinger_max_active_vertex(S) + 1; v++) {
+  for (uint64_t v=0; v < stinger_max_active_vertex(S) + 1; v++) {
     if (v < 4) {
       EXPECT_NEAR(expected_pr[v],pr[v]*ratio,tol);
       leftover -= pr[v];

--- a/src/tests/pagerank_test/undirected_princeton.cpp
+++ b/src/tests/pagerank_test/undirected_princeton.cpp
@@ -49,7 +49,7 @@ TEST_F(PagerankUndirectedPrincetonTest, Pagerank) {
 
   double tol = 0.001;
 
-  for (int64_t v=0; v < stinger_max_active_vertex(S) + 1; v++) {
+  for (uint64_t v=0; v < stinger_max_active_vertex(S) + 1; v++) {
     EXPECT_NEAR(expected_pr[v],pr[v],tol);
   }
 
@@ -88,7 +88,7 @@ TEST_F(PagerankUndirectedPrincetonTest, PagerankSubset) {
 
   double tol = 0.001;
 
-  for (int64_t v=0; v < stinger_max_active_vertex(S) + 1; v++) {
+  for (uint64_t v=0; v < stinger_max_active_vertex(S) + 1; v++) {
     if (v < 4) {
       EXPECT_NEAR(expected_pr[v],pr[v],tol);
     } else {
@@ -113,7 +113,7 @@ TEST_F(PagerankUndirectedPrincetonTest, PagerankType) {
   tmp_pr = (double *)xcalloc(nv, sizeof(double));
   pr = (double *)xcalloc(nv, sizeof(double));
 
-  for(uint64_t v = 0; v < nv; v++) {
+  for(int64_t v = 0; v < nv; v++) {
     pr[v] = 1 / ((double)nv);
   }
 
@@ -131,7 +131,7 @@ TEST_F(PagerankUndirectedPrincetonTest, PagerankType) {
 
   double leftover = 1.0;
 
-  for (int64_t v=0; v < stinger_max_active_vertex(S) + 1; v++) {
+  for (uint64_t v=0; v < stinger_max_active_vertex(S) + 1; v++) {
     if (v < 4) {
       EXPECT_NEAR(expected_pr[v],pr[v]*ratio,tol);
       leftover -= pr[v];

--- a/src/tests/stinger_batch_test/stinger_batch_test.cpp
+++ b/src/tests/stinger_batch_test/stinger_batch_test.cpp
@@ -50,7 +50,7 @@ protected:
 };
 
 TEST_F(StingerBatchTest, single_insertion) {
-    int64_t total_edges = 0;
+    /*int64_t total_edges = 0;*/
 
     // Create batch to insert
     std::vector<update> updates;
@@ -273,7 +273,7 @@ TEST_F(StingerBatchTest, typed_batch_insertion) {
     // Create batch to insert
     std::vector<update> updates;
     for (int i=0; i < 100; i++) {
-        for (int type = 0; type < S->max_netypes; type++) {
+        for (size_t type = 0; type < S->max_netypes; type++) {
             update u = {
                 type, // type
                 i, // source
@@ -293,7 +293,7 @@ TEST_F(StingerBatchTest, typed_batch_insertion) {
     EXPECT_EQ(consistency,0);
 
     // Check to make sure the edges were inserted with the correct types
-    for (int type = 0; type < S->max_netypes; type++) {
+    for (size_t type = 0; type < S->max_netypes; type++) {
         int num_edges = 0;
         STINGER_FORALL_EDGES_BEGIN(S, type){
             num_edges += 1;

--- a/src/tests/stinger_core_test/stinger_core_test.cpp
+++ b/src/tests/stinger_core_test/stinger_core_test.cpp
@@ -356,7 +356,7 @@ TEST_F(StingerCoreTest, stinger_edge_insertion) {
   }
 
   STINGER_FORALL_EDGES_OF_ALL_TYPES_BEGIN(S) {
-    int64_t expected_timestamp = std::min(STINGER_EDGE_SOURCE,STINGER_EDGE_DEST) + 1;
+    (void) (std::min(STINGER_EDGE_SOURCE,STINGER_EDGE_DEST) + 1);
     total_edges--;
   } STINGER_FORALL_EDGES_OF_ALL_TYPES_END();
   EXPECT_EQ(total_edges,0);
@@ -469,9 +469,9 @@ TEST_F(StingerCoreTest, stinger_delete_edges) {
   OMP("omp parallel for")
   for (int i=0; i < 100; i++) {
     int64_t timestamp = i+1;
-    int64_t ret;
+    /*int64_t ret;*/
     for (int j=i+1; j < 100; j++) {
-      ret = stinger_insert_edge_pair(S, 0, i, j, 1, timestamp);
+      (void) stinger_insert_edge_pair(S, 0, i, j, 1, timestamp);
     }
   }
 
@@ -479,9 +479,9 @@ TEST_F(StingerCoreTest, stinger_delete_edges) {
   OMP("omp parallel for")
   for (int i=0; i < 100; i++) {
     int64_t timestamp = i+1;
-    int64_t ret;
+    /*int64_t ret;*/
     for (int j=i+1; j < 100; j++) {
-      ret = stinger_insert_edge(S, 1, i, j, 1, timestamp);
+      (void) stinger_insert_edge(S, 1, i, j, 1, timestamp);
     }
   }
 
@@ -533,14 +533,14 @@ TEST_F(StingerCoreTest, stinger_delete_edges) {
 }
 
 TEST_F(StingerCoreTest, racing_deletions) {
-  int64_t ret;
+  /*int64_t ret;*/
   // Insert undirected edges
   OMP("omp parallel for")
   for (int i=0; i < 100; i++) {
     int64_t timestamp = i+1;
-    int64_t ret;
+    /*int64_t ret;*/
     for (int j=i+1; j < 100; j++) {
-      ret = stinger_insert_edge_pair(S, 0, i, j, 1, timestamp);
+      (void) stinger_insert_edge_pair(S, 0, i, j, 1, timestamp);
     }
   }
 
@@ -549,10 +549,10 @@ TEST_F(StingerCoreTest, racing_deletions) {
       OMP("omp parallel") {
         OMP ("omp sections") {
           OMP("omp section") {
-            ret = stinger_remove_edge(S, 0, i, j);
+            (void) stinger_remove_edge(S, 0, i, j);
           }
           OMP("omp section") {
-            ret = stinger_remove_edge(S, 0, j, i);
+            (void) stinger_remove_edge(S, 0, j, i);
           }
         }
       }
@@ -568,24 +568,24 @@ TEST_F(StingerCoreTest, stinger_remove_vertex) {
   // Insert undirected edges
   for (int i=0; i < 100; i++) {
     int64_t timestamp = i+1;
-    int64_t ret;
+    /*int64_t ret;*/
     for (int j=i+1; j < 100; j++) {
-      ret = stinger_insert_edge_pair(S, 0, i, j, 1, timestamp);
+      (void) stinger_insert_edge_pair(S, 0, i, j, 1, timestamp);
     }
   }
 
   // Insert some directed out edges from vertex 1
   for (int i=101; i < 500; i+=4) {
     int64_t timestamp = 2;
-    int64_t ret;    
-    ret = stinger_insert_edge(S, 0, 1, i, 1, timestamp);
+    /*int64_t ret;    */
+    (void) stinger_insert_edge(S, 0, 1, i, 1, timestamp);
   }
 
   // Insert some directed in edges to vertex 2
   for (int i=102; i < 500; i+=4) {
     int64_t timestamp = 2;
-    int64_t ret;    
-    ret = stinger_insert_edge(S, 0, i, 2, 1, timestamp);
+    /*int64_t ret;    */
+    (void) stinger_insert_edge(S, 0, i, 2, 1, timestamp);
   }
 
   // PART 1: remove a vertex with all undirected edges
@@ -608,7 +608,7 @@ TEST_F(StingerCoreTest, stinger_remove_vertex) {
   bool in_edge_list = false;
 
   STINGER_FORALL_EDGES_OF_VTX_BEGIN(S,3) {
-    fprintf(stderr,"%ld %ld %ld\n",STINGER_EDGE_SOURCE,STINGER_EDGE_DEST,STINGER_EDGE_DIRECTION);
+    fprintf(stderr,"%" PRId64 " %" PRId64 " %" PRId64 "\n",STINGER_EDGE_SOURCE,STINGER_EDGE_DEST,STINGER_EDGE_DIRECTION);
     has_edge_list = true;
   } STINGER_FORALL_EDGES_OF_VTX_END();
   EXPECT_FALSE(has_edge_list) << "Vertex should have no incident edges";

--- a/src/tests/stinger_physmap_test/stinger_physmap_test.cpp
+++ b/src/tests/stinger_physmap_test/stinger_physmap_test.cpp
@@ -38,7 +38,7 @@ TEST_F(StingerPhysmapTest, create) {
   char * name = (char*)xcalloc(100,sizeof(char));
 
   for (i=0; i < (1<<13); i++) {
-    snprintf(name, 100, "Vertex_%ld", i);
+    snprintf(name, 100, "Vertex_%" PRId64, i);
     ret = stinger_mapping_create(S, name, strlen(name), &vtx_out);
     EXPECT_EQ(ret,1);
     EXPECT_EQ(vtx_out,i);    
@@ -67,7 +67,7 @@ TEST_F(StingerPhysmapTest, lookup) {
   char * name = (char*)xcalloc(100,sizeof(char));
 
   for (i=0; i < (1<<13); i++) {
-    snprintf(name, 100, "Vertex_%ld", i);
+    snprintf(name, 100, "Vertex_%" PRId64, i);
     stinger_mapping_create(S, name, strlen(name), &vtx_out);
   }
 
@@ -89,7 +89,7 @@ TEST_F(StingerPhysmapTest, physid_lookup) {
   char * name = (char*)xcalloc(100,sizeof(char));
 
   for (i=0; i < (1<<13); i++) {
-    snprintf(name, 100, "Vertex_%ld", i);
+    snprintf(name, 100, "Vertex_%" PRId64, i);
     stinger_mapping_create(S, name, strlen(name), &vtx_out);
   }
 
@@ -128,7 +128,7 @@ TEST_F(StingerPhysmapTest, physid_lookup) {
   lookupName = NULL;
 
   len = 0;
-  ret = stinger_mapping_physid_get(S, 1<<13 + 1, &lookupName, &len);
+  ret = stinger_mapping_physid_get(S, 1<<(13 + 1), &lookupName, &len);
   EXPECT_EQ(ret,-1);
   EXPECT_EQ(lookupName,(void*)NULL);
 }

--- a/src/tests/stinger_traversal_test/stinger_traversal_test.h
+++ b/src/tests/stinger_traversal_test/stinger_traversal_test.h
@@ -28,7 +28,7 @@ protected:
     for (int i=0; i < 10; i++) {
       for (int j=i+1; j < 10; j++) {
         int64_t type = (j % 2 == 1)?1:0;
-        int64_t ret = stinger_insert_edge_pair(S, type, i, j, 1, timestamp);
+        (void) stinger_insert_edge_pair(S, type, i, j, 1, timestamp);
         expected_out_edges[std::make_pair(type,i)].insert(j);
         expected_out_edges[std::make_pair(type,j)].insert(i);
 

--- a/src/tests/streaming_connected_components_test/scc_test.cpp
+++ b/src/tests/streaming_connected_components_test/scc_test.cpp
@@ -61,7 +61,7 @@ TEST_F(SCCTest, UndirectedGraph) {
   parallel_shiloach_vishkin_components_of_type(S, expected_components,0);
 
   uint64_t expected_num_components = 0,actual_num_components=0;
-  for(uint64_t v = 0; v < nv; v++) {
+  for(int64_t v = 0; v < nv; v++) {
     if (v==expected_components[v])
       expected_num_components++;
     if (v==actual_components[v])
@@ -69,7 +69,7 @@ TEST_F(SCCTest, UndirectedGraph) {
   }  
   EXPECT_EQ(actual_num_components,expected_num_components);
 
-  for(uint64_t v = 0; v < nv; v++) {
+  for(int64_t v = 0; v < nv; v++) {
     EXPECT_EQ(actual_components[v],expected_components[v]);
   }
 
@@ -120,7 +120,7 @@ TEST_F(SCCTest, UndirectedGraphDumbbell) {
   int64_t* expected_components = (int64_t*)malloc(sizeof(int64_t)*nv);
   parallel_shiloach_vishkin_components_of_type(S, expected_components,0);
   uint64_t expected_num_components = 0,actual_num_components=0;
-  for(uint64_t v = 0; v < nv; v++) {
+  for(int64_t v = 0; v < nv; v++) {
     if (v==expected_components[v])
       expected_num_components++;
     if (v==actual_components[v])
@@ -128,7 +128,7 @@ TEST_F(SCCTest, UndirectedGraphDumbbell) {
   }  
   EXPECT_EQ(actual_num_components,expected_num_components);
 
-  for(uint64_t v = 0; v < nv; v++) {
+  for(int64_t v = 0; v < nv; v++) {
     EXPECT_EQ(actual_components[v],expected_components[v]);
   }
   free(expected_components);


### PR DESCRIPTION
I cleaned up the code a bit in order to compile warning-free on gcc 6.0. This should be helpful for better maintainability and portability.