### PR TITLE
portability fixes

### DIFF
--- a/src/clients/algorithms/clustering_coefficients/src/clustering.c
+++ b/src/clients/algorithms/clustering_coefficients/src/clustering.c
@@ -36,7 +36,7 @@ main(int argc, char *argv[])
   double * local_cc = (double *)alg->alg_data;
   int64_t * ntri = (int64_t *)(((double *)alg->alg_data) + alg->stinger->max_nv);
 
-  int64_t * affected = xcalloc (alg->stinger->max_nv, sizeof (int64_t *));
+  int64_t * affected = xcalloc (alg->stinger->max_nv, sizeof (int64_t));
 
   init_timer();
   double time;

--- a/src/clients/streams/random_edge_generator/src/main.cpp
+++ b/src/clients/streams/random_edge_generator/src/main.cpp
@@ -94,7 +94,7 @@ main(int argc, char *argv[])
     }
   }
 
-  if (nv > 1L<<31) {
+  if (nv > 1UL<<31) {
     fprintf (stderr, "generator does not support nv > 2**31  (requested %ld)\n", (long)nv);
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
Fixed some non-portable assumptions (1<<31 fitting into a signed long value, int64_t having the same size as a pointer) that caused run-time errors on 32-bit platforms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingergraph/stinger/220)
<!-- Reviewable:end -->
