### PR TITLE
Fix typo in link to dev build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 STINGER
 =======
 [![Build Status (master)](https://travis-ci.org/stingergraph/stinger.png?branch=master)](https://travis-ci.org/stingergraph/stinger)
-[![Build Status (dev)](https://travis-ci.org/stingergraph/stinger.png?branch=dev)](https://travis-ci.org/stginergraph/stinger)
+[![Build Status (dev)](https://travis-ci.org/stingergraph/stinger.png?branch=dev)](https://travis-ci.org/stingergraph/stinger)
 
 Learn more at [stingergraph.com](http://stingergraph.com).
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingergraph/stinger/223)
<!-- Reviewable:end -->
