### PR TITLE
Revert "Merge pull request #215 from ehein6/full-empty-volatile"

### DIFF
--- a/lib/stinger_core/CMakeLists.txt
+++ b/lib/stinger_core/CMakeLists.txt
@@ -8,7 +8,6 @@ set(sources
 	src/stinger_shared.c
 	src/stinger_vertex.c
 	src/xmalloc.c
-	src/x86_full_empty.c
 )
 set(headers
 	inc/core_util.h
@@ -26,6 +25,9 @@ set(headers
 	inc/xmalloc.h
 	inc/stinger_batch_insert.h
 )
+set(unoptimized_sources
+	src/x86_full_empty.c
+)
 
 set(config
 	stinger_names.h
@@ -38,7 +40,8 @@ include_directories("${CMAKE_BINARY_DIR}/include/stinger_core")
 include_directories("${CMAKE_BINARY_DIR}/include/stinger_utils")
 
 set_source_files_properties(${config} PROPERTIES GENERATED TRUE)
-add_library(stinger_core SHARED ${sources} ${headers} ${config})
+set_source_files_properties(${unoptimized_sources} PROPERTIES COMPILE_FLAGS -O0)
+add_library(stinger_core SHARED ${sources} ${unoptimized_sources} ${headers} ${config})
 if(OPENMP_FOUND)
   target_compile_definitions(stinger_core PUBLIC _GLIBCXX_PARALLEL)
 endif()

--- a/lib/stinger_core/inc/stinger_atomics.h
+++ b/lib/stinger_core/inc/stinger_atomics.h
@@ -9,7 +9,6 @@ extern "C" {
 
 #include "stinger.h"
 
-static inline void stinger_memory_barrier();
 static inline int stinger_int_fetch_add (int *, int);
 static inline int64_t stinger_int64_fetch_add (int64_t *, int64_t);
 static inline uint64_t stinger_uint64_fetch_add (uint64_t *, uint64_t);
@@ -27,12 +26,6 @@ static inline void *stinger_ptr_cas (void **, void *, void *);
 
 #if defined(__GNUC__)||defined(__INTEL_COMPILER)
 /* {{{ GCC / ICC defs */
-void
-stinger_memory_barrier()
-{
-  __sync_synchronize();
-}
-
 int
 stinger_int_fetch_add (int *x, int i)
 {
@@ -94,12 +87,6 @@ stinger_int64_cas (int64_t * x, int64_t origx, int64_t newx)
 /* }}} */
 #elif defined(__xlc__)
 /* {{{ XLC defs */
-void
-stinger_memory_barrier()
-{
-  __sync_synchronize();
-}
-
 int
 stinger_int_fetch_add (int *x, int i)
 {
@@ -166,11 +153,6 @@ stinger_int64_cas (int64_t * x, int64_t origx, int64_t newx)
 #elif !defined(_OPENMP)
 #warning "Assuming no parallel / concurrent operations necessary."
 /* {{{ Not concurrent */
-void
-stinger_memory_barrier()
-{
-}
-
 int
 stinger_int_fetch_add (int *v, int x)
 {

--- a/lib/stinger_core/inc/x86_full_empty.h
+++ b/lib/stinger_core/inc/x86_full_empty.h
@@ -27,19 +27,19 @@ extern "C" {
 #define MARKER UINT64_MAX
 
 uint64_t 
-readfe(volatile uint64_t * v);
+readfe(uint64_t * v);
 
 uint64_t
-writeef(volatile uint64_t * v, uint64_t new_val);
+writeef(uint64_t * v, uint64_t new_val);
 
 uint64_t
-readff(volatile uint64_t * v);
+readff(uint64_t * v);
 
 uint64_t
-writeff(volatile uint64_t * v, uint64_t new_val);
+writeff(uint64_t * v, uint64_t new_val);
 
 uint64_t
-writexf(volatile uint64_t * v, uint64_t new_val);
+writexf(uint64_t * v, uint64_t new_val);
 
 #ifdef __cplusplus
 }

--- a/lib/stinger_core/src/x86_full_empty.c
+++ b/lib/stinger_core/src/x86_full_empty.c
@@ -1,10 +1,13 @@
-/* Emulation of Full Empty Bits Using atomic check-and-swap.
+/* x86 Emulation of Full Empty Bits Using atomic check-and-swap.
  *
  * NOTES:
- * - Using these functions means that the MARKER value defined
- *   below must be reserved in your application and CANNOT be
+ * - Using these functions means that the MARKER value defined 
+ *   below must be reserved in your application and CANNOT be 
  *   considered a normal value.  Feel free to change the value to
  *   suit your application.
+ * - Do not compile this file with optimization.  There are loops
+ *   that do not make sense in a serial context.  The compiler will
+ *   optimize them out.
  * - Improper use of these functions can and will result in deadlock.
  *
  * author: rmccoll3@gatech.edu
@@ -12,9 +15,8 @@
 
 #include  "x86_full_empty.h"
 
-uint64_t
-readfe(volatile uint64_t * v) {
-  stinger_memory_barrier();
+uint64_t 
+readfe(uint64_t * v) {
   uint64_t val;
   while(1) {
     val = *v;
@@ -28,8 +30,7 @@ readfe(volatile uint64_t * v) {
 }
 
 uint64_t
-writeef(volatile uint64_t * v, uint64_t new_val) {
-  stinger_memory_barrier();
+writeef(uint64_t * v, uint64_t new_val) {
   uint64_t val;
   while(1) {
     val = *v;
@@ -43,8 +44,7 @@ writeef(volatile uint64_t * v, uint64_t new_val) {
 }
 
 uint64_t
-readff(volatile uint64_t * v) {
-  stinger_memory_barrier();
+readff(uint64_t * v) {
   uint64_t val = *v;
   while(val == MARKER) {
     val = *v;
@@ -53,8 +53,7 @@ readff(volatile uint64_t * v) {
 }
 
 uint64_t
-writeff(volatile uint64_t * v, uint64_t new_val) {
-  stinger_memory_barrier();
+writeff(uint64_t * v, uint64_t new_val) {
   uint64_t val;
   while(1) {
     val = *v;
@@ -68,9 +67,7 @@ writeff(volatile uint64_t * v, uint64_t new_val) {
 }
 
 uint64_t
-writexf(volatile uint64_t * v, uint64_t new_val) {
-  stinger_memory_barrier();
+writexf(uint64_t * v, uint64_t new_val) {
   *v = new_val;
-  stinger_memory_barrier();
   return new_val;
 }


### PR DESCRIPTION
This reverts commit ac933f233712f2e83913d1b8eadfcc544e9a1eef, reversing
changes made to 19fbb3bbb9bfd8ece5b7279496525a232377e86d.

This changed caused regression tests on Travis with GCC to slow down by
several orders of magnitude.  However we were unable to reproduce this
issue on any other machine.  Investigating.

Conflicts:
	lib/stinger_core/CMakeLists.txt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingergraph/stinger/226)
<!-- Reviewable:end -->
