### PR TITLE
Enforce alignment of stinger sub-structures.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,11 @@ set(STINGER_DEFAULT_NEB_FACTOR "4" CACHE STRING "Default number of edge blocks p
 set(STINGER_EDGEBLOCKSIZE "14" CACHE STRING "Number of edges per edge block")
 set(STINGER_NAME_STR_MAX "255" CACHE STRING "Max string length in physmap")
 
+MATH(EXPR STINGER_NAME_STR_MAX_ALIGN "(${STINGER_NAME_STR_MAX}+1) % 8")
+if (NOT STINGER_NAME_STR_MAX_ALIGN EQUAL 0)
+  MESSAGE(SEND_ERROR "STINGER_NAME_STR_MAX must be a multiple of 8 (minus one for null terminator).")
+endif()
+
 configure_file(${CMAKE_SOURCE_DIR}/lib/stinger_core/inc/stinger_defs.h.in ${CMAKE_BINARY_DIR}/include/stinger_core/stinger_defs.h @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/lib/stinger_core/inc/stinger_names.h.in ${CMAKE_BINARY_DIR}/include/stinger_core/stinger_names.h @ONLY)
 

--- a/lib/stinger_core/inc/stinger_names.h.in
+++ b/lib/stinger_core/inc/stinger_names.h.in
@@ -8,6 +8,11 @@ extern "C" {
 
 #define NAME_STR_MAX @STINGER_NAME_STR_MAX@
 
+// STINGER names storage must be 8-byte aligned
+#if (NAME_STR_MAX+1) % 8 != 0
+#error STINGER_NAME_STR_MAX must be a multiple of 8 (minus one for null terminator)
+#endif
+
 #ifdef NAME_USE_SQLITE
 	#include "sqlite/sqlite3.h"
 


### PR DESCRIPTION
STINGER makes one large contiguous allocation, then packs several sub-
structures into this chunk of memory. The alignment of each struct
within the chunk depends on the total length of all the structs and
arrays before it.

According to section 8.1.1 of the Intel® 64 and IA-32 Architectures
Developer's Manual: Vol. 3A, "Accesses to cacheable memory that are
split across cache lines and page boundaries are not guaranteed to be
atomic". Operations like readfe() and writeef() can cause deadlocks
if they operate on pointers to unaligned 64-bit data.

Most sub-structures are composed of int64_t's, so they are aligned
regardless of size. But stinger_names includes char arrays, the
size of which is specified by the configuration variable
STINGER_NAME_STR_MAX, plus one for a null terminator byte. The
default value of 255 works, but changing this value can break the
alignment of the other structures, causing deadlocks.

This patch adds several checks to ensure that the all of the
STINGER sub-structures are aligned to an 8-byte boundary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingergraph/stinger/229)
<!-- Reviewable:end -->
