### PR TITLE
Generate stinger_net headers before stinger_alg.

### DIFF
--- a/lib/stinger_alg/CMakeLists.txt
+++ b/lib/stinger_alg/CMakeLists.txt
@@ -51,4 +51,4 @@ include_directories("${CMAKE_BINARY_DIR}/include/stinger_net")
 
 set_source_files_properties(${config} PROPERTIES GENERATED TRUE)
 add_library(stinger_alg ${sources} ${headers} ${config})
-target_link_libraries(stinger_alg stinger_core compat)
+target_link_libraries(stinger_alg stinger_core stinger_net stinger_utils compat)


### PR DESCRIPTION
stinger_alg does not need to link with stinger_net, but it does
include some headers from there. Commit b7b821a removed stinger_net
as a link dependency. An unintended consequence of this change
combined with how we generate headers and how CMake detects build
dependencies, it was possible that a parallel make would try to
build stinger_alg before generating headers for stinger_net.

This commit adds the link dependency back, which forces CMake to
generate headers for stinger_net before stinger_alg is built.

Fixes #235.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingergraph/stinger/237)
<!-- Reviewable:end -->
